### PR TITLE
feat: add subagent session support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,12 +41,15 @@ Single-file CLI (`index.ts`) using `citty` for command parsing. All types, helpe
 | `messages` | Filtered, truncated message content by role/type/turn |
 | `slice` | Raw entries for a turn range |
 | `search` | Find sessions matching structured queries (tool, file, text, bash filters) |
+| `subagents` | List subagents for a session with metadata |
 
-All session-scoped commands accept a positional session identifier (UUID, UUID prefix, or slug) and an optional `--project` flag (defaults to CWD).
+All session-scoped commands accept a positional session identifier (UUID, UUID prefix, or slug) and an optional `--project` flag (defaults to CWD). Subagent sessions can be targeted using colon notation: `<session>:<agent-id>` (e.g., `DA2738E3:a8361bc`).
 
 ### Session Resolution
 
 Sessions are resolved in order: exact UUID filename match, UUID prefix match, then slug search (first 8KB of each JSONL file). Ambiguous matches are errors. Input is validated against `[a-zA-Z0-9-]` to prevent path traversal.
+
+**Subagent targeting:** Use colon notation `<session>:<agent-id>` to address a subagent session (e.g., `DA2738E3:a8361bc`). The session part is resolved normally, then the subagent file is located at `<session-dir>/subagents/agent-<agent-id>.jsonl`. Agent IDs allow underscores: `[a-zA-Z0-9_-]+`. All session-scoped commands support this notation. The `subagents` command lists available agent IDs for a given session.
 
 ### Key Design Decisions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,9 @@ All session-scoped commands accept a positional session identifier (UUID, UUID p
 
 ### Session Resolution
 
-Sessions are resolved in order: exact UUID filename match, UUID prefix match, then slug search (first 8KB of each JSONL file). Ambiguous matches are errors. Input is validated against `[a-zA-Z0-9-]` to prevent path traversal.
+Sessions are resolved in order: exact UUID filename match, UUID prefix match, then slug search (first 8KB of each JSONL file). Ambiguous matches are errors. Session input is validated against `[a-zA-Z0-9-]` and agent IDs against `[a-zA-Z0-9_-]` to prevent path traversal.
 
-**Subagent targeting:** Use colon notation `<session>:<agent-id>` to address a subagent session (e.g., `DA2738E3:a8361bc`). The session part is resolved normally, then the subagent file is located at `<session-dir>/subagents/agent-<agent-id>.jsonl`. Agent IDs allow underscores: `[a-zA-Z0-9_-]+`. All session-scoped commands support this notation. The `subagents` command lists available agent IDs for a given session.
+**Subagent targeting:** Use colon notation `<session>:<agent-id>` to address a subagent session (e.g., `DA2738E3:a8361bc`). The session part is resolved normally, then the subagent file is located at `<session-dir>/subagents/agent-<agent-id>.jsonl`. Agent IDs allow underscores: `[a-zA-Z0-9_-]+`. All session-scoped commands except `subagents` support this notation. The `subagents` command lists available agent IDs for a given session.
 
 ### Key Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ All commands except `list` require a `<session>` argument. Three forms are accep
 
 All session commands accept `--project <path>` to specify the project directory (defaults to CWD).
 
-**Subagent targeting:** Append `:<agent-id>` to any session identifier to target a subagent session (e.g., `DA2738E3:a8361bc` or `snuggly-floating-barto:a8361bc`). The parent session is resolved normally, then the subagent file is located at `<session-dir>/subagents/agent-<agent-id>.jsonl`. Use the `subagents` command to discover available agent IDs.
+**Subagent targeting:** Append `:<agent-id>` to a session identifier in any session-scoped command (except `subagents`) to target a subagent session (e.g., `DA2738E3:a8361bc` or `snuggly-floating-barto:a8361bc`). The parent session is resolved normally, then the subagent file is located at `<session-dir>/subagents/agent-<agent-id>.jsonl`. Use the `subagents` command to discover available agent IDs.
 
 **Input validation:** Session IDs accept `[a-zA-Z0-9-]` characters; agent IDs also allow underscores `[a-zA-Z0-9_-]`. All other inputs are rejected with exit code 2.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ All commands except `list` require a `<session>` argument. Three forms are accep
 
 All session commands accept `--project <path>` to specify the project directory (defaults to CWD).
 
-**Input validation:** Only `[a-zA-Z0-9-]` characters are accepted; all other inputs are rejected with exit code 2.
+**Subagent targeting:** Append `:<agent-id>` to any session identifier to target a subagent session (e.g., `DA2738E3:a8361bc` or `snuggly-floating-barto:a8361bc`). The parent session is resolved normally, then the subagent file is located at `<session-dir>/subagents/agent-<agent-id>.jsonl`. Use the `subagents` command to discover available agent IDs.
+
+**Input validation:** Session IDs accept `[a-zA-Z0-9-]` characters; agent IDs also allow underscores `[a-zA-Z0-9_-]`. All other inputs are rejected with exit code 2.
 
 ### Turn Numbering
 
@@ -62,8 +64,9 @@ cc-session-tool list [--project <path>] [--branch <name>] [--after <date>] [--be
 | `--since`     | —       | Sessions from the last duration: `30m`, `2h`, `1d`, `1w` (mutually exclusive with `--after`) |
 | `--last`      | all     | Return only the N most recent sessions                         |
 | `--min-lines` | 0       | Sessions with at least N lines                                 |
+| `--include-subagents` | false | Include `subagent_count` per session                    |
 
-**Output:** Sessions sorted by timestamp (newest first). Fields may be `null` for sessions with missing metadata. When `--last` is used, `_meta.total` reflects the pre-limit count and `_meta.hasMore` is `true` if results were truncated.
+**Output:** Sessions sorted by timestamp (newest first). When `--include-subagents` is set, each session includes a `subagent_count` field; otherwise the field is omitted entirely. Fields may be `null` for sessions with missing metadata. When `--last` is used, `_meta.total` reflects the pre-limit count and `_meta.hasMore` is `true` if results were truncated.
 
 ```json
 {
@@ -99,6 +102,7 @@ cc-session-tool shape <session> [--project <path>]
   "ok": true,
   "data": {
     "session_id": "DA2738E3-...",
+    "agent_id": null,
     "turns": [
       { "n": 1, "role": "user", "type": "user", "block_index": 0 },
       { "n": 2, "role": "assistant", "type": "tool_use", "block_index": 0, "tools": ["Grep"] },
@@ -158,6 +162,7 @@ cc-session-tool tools <session> [--project <path>] [--name <tool>] [--failed] [-
   "ok": true,
   "data": {
     "session_id": "DA2738E3-...",
+    "agent_id": null,
     "tool_calls": [
       {
         "turn": 3,
@@ -229,6 +234,7 @@ cc-session-tool files <session> [--project <path>] [--group-by <file|turn>] [--t
   "ok": true,
   "data": {
     "session_id": "DA2738E3-...",
+    "agent_id": null,
     "group_by": "file",
     "files": [
       {
@@ -256,6 +262,7 @@ cc-session-tool files <session> [--project <path>] [--group-by <file|turn>] [--t
   "ok": true,
   "data": {
     "session_id": "DA2738E3-...",
+    "agent_id": null,
     "group_by": "turn",
     "accesses": [
       { "path": "/Users/me/project/src/auth.ts", "operation": "read", "turn": 6, "errored": false },
@@ -290,6 +297,7 @@ cc-session-tool tokens <session> [--project <path>] [--cumulative]
   "ok": true,
   "data": {
     "session_id": "DA2738E3-...",
+    "agent_id": null,
     "turns": [
       {
         "n": 2,
@@ -354,21 +362,25 @@ cc-session-tool messages <session> [--project <path>] [--role <user|assistant>] 
 ```json
 {
   "ok": true,
-  "data": [
-    {
-      "n": 1,
-      "role": "user",
-      "content": [{ "type": "text", "text": "Implement the feature..." }]
-    },
-    {
-      "n": 2,
-      "role": "assistant",
-      "content": [
-        { "type": "thinking", "text": "I need to...[truncated, 4832 chars]" },
-        { "type": "tool_use", "name": "Grep", "id": "toolu_abc123" }
-      ]
-    }
-  ],
+  "data": {
+    "session_id": "DA2738E3-...",
+    "agent_id": null,
+    "messages": [
+      {
+        "n": 1,
+        "role": "user",
+        "content": [{ "type": "text", "text": "Implement the feature..." }]
+      },
+      {
+        "n": 2,
+        "role": "assistant",
+        "content": [
+          { "type": "thinking", "text": "I need to...[truncated, 4832 chars]" },
+          { "type": "tool_use", "name": "Grep", "id": "toolu_abc123" }
+        ]
+      }
+    ]
+  },
   "_meta": { "total": 2, "returned": 2, "hasMore": false }
 }
 ```
@@ -397,7 +409,45 @@ cc-session-tool slice <session> --turn <N|N-M> [--project <path>] [--max-content
 **Notes:**
 
 - Without `--max-content`, entries are output as-is (full content preserved).
-- Output is wrapped in the standard `{ ok, data, _meta }` envelope where `data` is an array of raw session entries.
+- Output is wrapped in the standard `{ ok, data, _meta }` envelope where `data` is a structured object with `session_id`, `agent_id`, and `entries` (array of raw session entries). When targeting a subagent via colon notation, `agent_id` contains the agent ID; otherwise it is `null`.
+
+---
+
+### `subagents <session>`
+
+List subagents spawned during a session. Reads metadata from companion `.meta.json` files and counts JSONL lines for each subagent.
+
+```bash
+cc-session-tool subagents <session> [--project <path>]
+```
+
+**Output:**
+
+```json
+{
+  "ok": true,
+  "data": {
+    "session_id": "DA2738E3-...",
+    "subagents": [
+      {
+        "agent_id": "a8361bc",
+        "agent_type": "task",
+        "description": "Implement auth middleware",
+        "lines": 84,
+        "timestamp": "2026-03-07T22:35:00.000Z"
+      }
+    ]
+  },
+  "_meta": { "total": 1, "returned": 1, "hasMore": false }
+}
+```
+
+**Notes:**
+
+- Subagents are sorted by timestamp (newest first). Null timestamps sort to end.
+- `agent_type` and `description` come from `agent-<id>.meta.json`; both are `null` if the meta file is missing.
+- Use the returned `agent_id` with colon notation to target a subagent with any session-scoped command (e.g., `shape DA2738E3:a8361bc`).
+- Colon notation is rejected by this command (subagents of subagents do not exist).
 
 ## Composition Examples
 
@@ -462,6 +512,22 @@ cc-session-tool files DA2738E3 --group-by turn
 cc-session-tool tokens <planning-session>
 cc-session-tool tokens <implementation-session>
 # Compare input/output ratios and cache_read/cache_create patterns
+```
+
+### Inspect subagent activity
+
+```bash
+# Discover subagents spawned during a session
+cc-session-tool subagents DA2738E3
+
+# See what a specific subagent did
+cc-session-tool shape DA2738E3:a8361bc
+
+# Check tool calls in a subagent session
+cc-session-tool tools DA2738E3:a8361bc
+
+# List sessions with subagent counts
+cc-session-tool list --include-subagents
 ```
 
 ## Output Format

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ All commands use consistent turn numbering:
 Index all sessions by reading metadata from the first few lines of each file.
 
 ```bash
-cc-session-tool list [--project <path>] [--branch <name>] [--after <date>] [--before <date>] [--since <duration>] [--last <n>] [--min-lines <n>]
+cc-session-tool list [--project <path>] [--branch <name>] [--after <date>] [--before <date>] [--since <duration>] [--last <n>] [--min-lines <n>] [--include-subagents]
 ```
 
 | Option        | Default | Description                                                    |

--- a/index.test.ts
+++ b/index.test.ts
@@ -1014,6 +1014,15 @@ describe('resolveSessionFile', () => {
       expect(err.message).toContain('No subagent');
     }
   });
+
+  test('rejects path traversal in agent ID', async () => {
+    try {
+      await resolveSessionFile(CLAUDE_DIR, `${SESSION_ID}:../../../etc`);
+      expect(true).toBe(false);
+    } catch (err: any) {
+      expect(err.errorCode).toBe('INVALID_ID');
+    }
+  });
 });
 
 // ============================================================================
@@ -1045,6 +1054,14 @@ describe('resolveSession', () => {
     } catch (err: any) {
       expect(err.errorCode).toBe('NOT_FOUND');
     }
+  });
+
+  test('resolves subagent with colon notation', async () => {
+    const result = await resolveSession({ session: `${SESSION_ID}:${SUBAGENT_ID}`, project: FAKE_PROJECT });
+    expect(result.sessionId).toBe(SESSION_ID);
+    expect(result.agentId).toBe(SUBAGENT_ID);
+    expect(result.entries.length).toBe(2);
+    expect(result.entries.every(e => e.type === 'user' || e.type === 'assistant')).toBe(true);
   });
 });
 
@@ -1519,6 +1536,15 @@ describe('listSubagents', () => {
     // b9472cd has timestamp 2026-03-01T10:05:00.000Z (older)
     expect(result[0].agent_id).toBe('a8361bc');
     expect(result[1].agent_id).toBe('b9472cd');
+  });
+
+  test('rejects invalid session UUID', async () => {
+    try {
+      await listSubagents(CLAUDE_DIR, '../etc');
+      expect(true).toBe(false);
+    } catch (err: any) {
+      expect(err.errorCode).toBe('INVALID_ID');
+    }
   });
 });
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -7,6 +7,7 @@ import {
   parseTurnRange, truncateContent, inputSummary, determineOutcome, parseIntArg,
   extractFilePath, parseSince, buildResultLookup, extractSessionMetadata,
   resolveClaudeProjectDir, resolveSessionFile, resolveSession, parseSessionLines, userAssistantEntries,
+  listSubagents,
 } from './index.ts';
 
 // ============================================================================
@@ -433,11 +434,66 @@ function makeFixtureLines(): string[] {
   ];
 }
 
+const SUBAGENT_ID = 'a8361bc';
+
 beforeAll(() => {
   mkdirSync(FAKE_PROJECT, { recursive: true });
   mkdirSync(CLAUDE_DIR, { recursive: true });
   const lines = makeFixtureLines();
   writeFileSync(join(CLAUDE_DIR, `${SESSION_ID}.jsonl`), lines.join('\n') + '\n');
+
+  // Subagent fixture: create subagents dir within the parent session UUID dir
+  const subagentDir = join(CLAUDE_DIR, SESSION_ID, 'subagents');
+  mkdirSync(subagentDir, { recursive: true });
+  const subagentLines = [
+    JSON.stringify({
+      type: 'user',
+      sessionId: SESSION_ID,
+      timestamp: '2026-03-01T10:10:00.000Z',
+      gitBranch: 'main',
+      version: '2.1.0',
+      message: { role: 'user', content: 'Subagent task' },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-03-01T10:11:00.000Z',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Subagent response' }],
+        usage: { input_tokens: 40, output_tokens: 15 },
+      },
+    }),
+  ];
+  writeFileSync(join(subagentDir, `agent-${SUBAGENT_ID}.jsonl`), subagentLines.join('\n') + '\n');
+  writeFileSync(join(subagentDir, `agent-${SUBAGENT_ID}.meta.json`), JSON.stringify({
+    agentType: 'test-agent',
+    description: 'Test subagent',
+  }));
+
+  // Second subagent fixture WITHOUT .meta.json (for missing metadata tests)
+  const subagent2Id = 'b9472cd';
+  const subagent2Lines = [
+    JSON.stringify({
+      type: 'user',
+      sessionId: SESSION_ID,
+      timestamp: '2026-03-01T10:05:00.000Z',
+      gitBranch: 'main',
+      version: '2.1.0',
+      message: { role: 'user', content: 'Second subagent task' },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-03-01T10:06:00.000Z',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Second subagent response' }],
+        usage: { input_tokens: 30, output_tokens: 10 },
+      },
+    }),
+  ];
+  writeFileSync(join(subagentDir, `agent-${subagent2Id}.jsonl`), subagent2Lines.join('\n') + '\n');
+  // Intentionally no .meta.json for subagent2
+
   // Second fixture with same slug for ambiguous slug tests
   const lines2 = [
     JSON.stringify({
@@ -627,6 +683,7 @@ describe('shape integration', () => {
     expect(result.ok).toBe(true);
     const data = result.data;
     expect(data.session_id).toBe(SESSION_ID);
+    expect(data.agent_id).toBeNull();
     expect(data.summary.total_turns).toBe(6);
     expect(data.summary.user_messages).toBe(3);
     expect(data.summary.tool_calls.Grep).toBe(1);
@@ -657,6 +714,7 @@ describe('tools integration', () => {
     const { stdout } = await runCli(['tools', SESSION_ID, '--project', FAKE_PROJECT]);
     const result = parseOutput(stdout);
     expect(result.ok).toBe(true);
+    expect(result.data.agent_id).toBeNull();
     expect(result.data.tool_calls.length).toBe(2);
     expect(result.data.tool_calls[0].tool).toBe('Grep');
     expect(result.data.tool_calls[0].input_summary).toContain("pattern='hello'");
@@ -691,6 +749,7 @@ describe('tokens integration', () => {
     const { stdout } = await runCli(['tokens', SESSION_ID, '--project', FAKE_PROJECT]);
     const result = parseOutput(stdout);
     expect(result.ok).toBe(true);
+    expect(result.data.agent_id).toBeNull();
     expect(result.data.turns.length).toBe(3);
     expect(result.data.turns[0].n).toBe(2);
     expect(result.data.turns[0].input).toBe(100);
@@ -715,20 +774,22 @@ describe('messages integration', () => {
     const { stdout } = await runCli(['messages', SESSION_ID, '--project', FAKE_PROJECT]);
     const result = parseOutput(stdout);
     expect(result.ok).toBe(true);
-    expect(result.data.length).toBe(6);
+    expect(result.data.session_id).toBe(SESSION_ID);
+    expect(result.data.agent_id).toBeNull();
+    expect(result.data.messages.length).toBe(6);
   });
 
   test('filters by role', async () => {
     const { stdout } = await runCli(['messages', SESSION_ID, '--project', FAKE_PROJECT, '--role', 'user']);
     const result = parseOutput(stdout);
-    expect(result.data.every((m: any) => m.role === 'user')).toBe(true);
-    expect(result.data.length).toBe(3);
+    expect(result.data.messages.every((m: any) => m.role === 'user')).toBe(true);
+    expect(result.data.messages.length).toBe(3);
   });
 
   test('filters by type', async () => {
     const { stdout } = await runCli(['messages', SESSION_ID, '--project', FAKE_PROJECT, '--type', 'tool_use']);
     const result = parseOutput(stdout);
-    for (const msg of result.data) {
+    for (const msg of result.data.messages) {
       expect(msg.content.every((b: any) => b.type === 'tool_use')).toBe(true);
     }
   });
@@ -736,15 +797,15 @@ describe('messages integration', () => {
   test('filters by turn range', async () => {
     const { stdout } = await runCli(['messages', SESSION_ID, '--project', FAKE_PROJECT, '--turn', '1-2']);
     const result = parseOutput(stdout);
-    expect(result.data.length).toBe(2);
-    expect(result.data[0].n).toBe(1);
-    expect(result.data[1].n).toBe(2);
+    expect(result.data.messages.length).toBe(2);
+    expect(result.data.messages[0].n).toBe(1);
+    expect(result.data.messages[1].n).toBe(2);
   });
 
   test('truncates content', async () => {
     const { stdout } = await runCli(['messages', SESSION_ID, '--project', FAKE_PROJECT, '--max-content', '10']);
     const result = parseOutput(stdout);
-    const userMsg = result.data.find((m: any) => m.n === 1);
+    const userMsg = result.data.messages.find((m: any) => m.n === 1);
     expect(userMsg.content[0].text).toContain('...[truncated,');
   });
 });
@@ -754,16 +815,18 @@ describe('slice integration', () => {
     const { stdout } = await runCli(['slice', SESSION_ID, '--project', FAKE_PROJECT, '--turn', '1-2']);
     const result = parseOutput(stdout);
     expect(result.ok).toBe(true);
-    expect(result.data.length).toBe(2);
-    expect(result.data[0].type).toBe('user');
-    expect(result.data[1].type).toBe('assistant');
+    expect(result.data.session_id).toBe(SESSION_ID);
+    expect(result.data.agent_id).toBeNull();
+    expect(result.data.entries.length).toBe(2);
+    expect(result.data.entries[0].type).toBe('user');
+    expect(result.data.entries[1].type).toBe('assistant');
   });
 
   test('truncates content with max-content', async () => {
     const { stdout } = await runCli(['slice', SESSION_ID, '--project', FAKE_PROJECT, '--turn', '2', '--max-content', '10']);
     const result = parseOutput(stdout);
-    expect(result.data.length).toBe(1);
-    const blocks = result.data[0].message.content;
+    expect(result.data.entries.length).toBe(1);
+    const blocks = result.data.entries[0].message.content;
     const thinking = blocks.find((b: any) => b.type === 'thinking');
     expect(thinking.thinking).toContain('...[truncated,');
   });
@@ -869,7 +932,9 @@ describe('resolveSessionFile', () => {
 
   test('exact UUID match resolves', async () => {
     const result = await resolveSessionFile(CLAUDE_DIR, SESSION_ID);
-    expect(result).toBe(join(CLAUDE_DIR, `${SESSION_ID}.jsonl`));
+    expect(result.filePath).toBe(join(CLAUDE_DIR, `${SESSION_ID}.jsonl`));
+    expect(result.sessionId).toBe(SESSION_ID);
+    expect(result.agentId).toBeNull();
   });
 
   test('non-existent session throws NOT_FOUND', async () => {
@@ -890,6 +955,65 @@ describe('resolveSessionFile', () => {
       expect(err.message).toContain('Ambiguous slug');
     }
   });
+
+  // Colon notation tests
+  test('colon notation resolves to ResolvedFile with correct fields', async () => {
+    const result = await resolveSessionFile(CLAUDE_DIR, `${SESSION_ID}:${SUBAGENT_ID}`);
+    expect(result.sessionId).toBe(SESSION_ID);
+    expect(result.agentId).toBe(SUBAGENT_ID);
+    expect(result.filePath).toBe(join(CLAUDE_DIR, SESSION_ID, 'subagents', `agent-${SUBAGENT_ID}.jsonl`));
+  });
+
+  test('empty agent ID throws INVALID_ID', async () => {
+    try {
+      await resolveSessionFile(CLAUDE_DIR, `${SESSION_ID}:`);
+      expect(true).toBe(false);
+    } catch (err: any) {
+      expect(err.errorCode).toBe('INVALID_ID');
+      expect(err.message).toContain('Invalid agent ID');
+    }
+  });
+
+  test('empty session part throws INVALID_ID', async () => {
+    try {
+      await resolveSessionFile(CLAUDE_DIR, ':some-agent');
+      expect(true).toBe(false);
+    } catch (err: any) {
+      expect(err.errorCode).toBe('INVALID_ID');
+      expect(err.message).toContain('Invalid session ID portion');
+    }
+  });
+
+  test('multiple colons throws INVALID_ID (agent part contains colon)', async () => {
+    try {
+      await resolveSessionFile(CLAUDE_DIR, 'a:b:c');
+      expect(true).toBe(false);
+    } catch (err: any) {
+      expect(err.errorCode).toBe('INVALID_ID');
+      expect(err.message).toContain('Invalid agent ID');
+    }
+  });
+
+  test('underscore in agent ID is valid (validates regex but throws NOT_FOUND)', async () => {
+    try {
+      await resolveSessionFile(CLAUDE_DIR, `${SESSION_ID}:aprompt_suggestion-b96624`);
+      expect(true).toBe(false);
+    } catch (err: any) {
+      // Passes regex validation (underscores allowed in agent IDs) but file doesn't exist
+      expect(err.errorCode).toBe('NOT_FOUND');
+      expect(err.message).toContain('No subagent');
+    }
+  });
+
+  test('non-existent subagent throws NOT_FOUND', async () => {
+    try {
+      await resolveSessionFile(CLAUDE_DIR, `${SESSION_ID}:nonexistent-agent`);
+      expect(true).toBe(false);
+    } catch (err: any) {
+      expect(err.errorCode).toBe('NOT_FOUND');
+      expect(err.message).toContain('No subagent');
+    }
+  });
 });
 
 // ============================================================================
@@ -897,9 +1021,10 @@ describe('resolveSessionFile', () => {
 // ============================================================================
 
 describe('resolveSession', () => {
-  test('returns sessionId and filtered entries', async () => {
+  test('returns sessionId, agentId, and filtered entries', async () => {
     const result = await resolveSession({ session: SESSION_ID, project: FAKE_PROJECT });
     expect(result.sessionId).toBe(SESSION_ID);
+    expect(result.agentId).toBeNull();
     expect(result.entries.length).toBeGreaterThan(0);
     expect(result.entries.every(e => e.type === 'user' || e.type === 'assistant')).toBe(true);
   });
@@ -1125,6 +1250,7 @@ describe('files integration', () => {
     expect(exitCode).toBe(0);
     const result = parseOutput(stdout);
     expect(result.ok).toBe(true);
+    expect(result.data.agent_id).toBeNull();
     expect(result.data.group_by).toBe('file');
     expect(result.data.files.length).toBe(2);
 
@@ -1354,5 +1480,205 @@ describe('search integration', () => {
     expect(result._meta.total).toBeGreaterThan(result._meta.returned);
     expect(result._meta.returned).toBe(1);
     expect(result._meta.hasMore).toBe(true);
+  });
+});
+
+// ============================================================================
+// listSubagents unit tests
+// ============================================================================
+
+describe('listSubagents', () => {
+  test('returns empty array when subagents directory does not exist', async () => {
+    const result = await listSubagents(CLAUDE_DIR, SESSION_ID_2);
+    expect(result).toEqual([]);
+  });
+
+  test('returns correct metadata from .meta.json', async () => {
+    const result = await listSubagents(CLAUDE_DIR, SESSION_ID);
+    const agent = result.find(a => a.agent_id === 'a8361bc');
+    expect(agent).toBeDefined();
+    expect(agent!.agent_type).toBe('test-agent');
+    expect(agent!.description).toBe('Test subagent');
+    expect(agent!.lines).toBe(2);
+    expect(agent!.timestamp).toBe('2026-03-01T10:10:00.000Z');
+  });
+
+  test('missing .meta.json returns null agent_type and description', async () => {
+    const result = await listSubagents(CLAUDE_DIR, SESSION_ID);
+    const agent = result.find(a => a.agent_id === 'b9472cd');
+    expect(agent).toBeDefined();
+    expect(agent!.agent_type).toBeNull();
+    expect(agent!.description).toBeNull();
+    expect(agent!.lines).toBe(2);
+  });
+
+  test('results are sorted by timestamp descending (newest first)', async () => {
+    const result = await listSubagents(CLAUDE_DIR, SESSION_ID);
+    expect(result.length).toBe(2);
+    // a8361bc has timestamp 2026-03-01T10:10:00.000Z (newer)
+    // b9472cd has timestamp 2026-03-01T10:05:00.000Z (older)
+    expect(result[0].agent_id).toBe('a8361bc');
+    expect(result[1].agent_id).toBe('b9472cd');
+  });
+});
+
+// ============================================================================
+// subagents integration tests
+// ============================================================================
+
+describe('subagents integration', () => {
+  test('returns correct metadata for session with subagents', async () => {
+    const { exitCode, stdout } = await runCli(['subagents', SESSION_ID, '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.session_id).toBe(SESSION_ID);
+    expect(result.data.subagents.length).toBe(2);
+    const agent = result.data.subagents.find((a: any) => a.agent_id === 'a8361bc');
+    expect(agent).toBeDefined();
+    expect(agent.agent_type).toBe('test-agent');
+    expect(agent.description).toBe('Test subagent');
+    expect(agent.lines).toBe(2);
+  });
+
+  test('returns success with empty subagents array for session without subagents', async () => {
+    const { exitCode, stdout } = await runCli(['subagents', SESSION_ID_2, '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.session_id).toBe(SESSION_ID_2);
+    expect(result.data.subagents).toEqual([]);
+    expect(result._meta.total).toBe(0);
+  });
+
+  test('rejects colon notation with INVALID_ARGS error', async () => {
+    const { exitCode, stdout } = await runCli(['subagents', `${SESSION_ID}:${SUBAGENT_ID}`, '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(2);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe('INVALID_ARGS');
+    expect(result.error.message).toContain('parent session ID');
+  });
+
+  test('non-existent session returns NOT_FOUND', async () => {
+    const { exitCode, stdout } = await runCli(['subagents', 'zzzzzzzz-0000-0000-0000-000000000000', '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(3);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe('NOT_FOUND');
+  });
+});
+
+// ============================================================================
+// Colon notation with session-scoped commands
+// ============================================================================
+
+describe('colon notation integration', () => {
+  test('shape <session>:<agent> processes subagent JSONL with correct agent_id', async () => {
+    const { exitCode, stdout } = await runCli(['shape', `${SESSION_ID}:${SUBAGENT_ID}`, '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.session_id).toBe(SESSION_ID);
+    expect(result.data.agent_id).toBe(SUBAGENT_ID);
+    expect(result.data.summary.total_turns).toBe(2);
+    expect(result.data.summary.user_messages).toBe(1);
+  });
+
+  test('tools <session>:<agent> works with agent_id', async () => {
+    const { exitCode, stdout } = await runCli(['tools', `${SESSION_ID}:${SUBAGENT_ID}`, '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.session_id).toBe(SESSION_ID);
+    expect(result.data.agent_id).toBe(SUBAGENT_ID);
+    expect(result.data.tool_calls.length).toBe(0); // subagent fixture has no tool_use blocks
+  });
+
+  test('messages <session>:<agent> has structured output with session_id and agent_id', async () => {
+    const { exitCode, stdout } = await runCli(['messages', `${SESSION_ID}:${SUBAGENT_ID}`, '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.session_id).toBe(SESSION_ID);
+    expect(result.data.agent_id).toBe(SUBAGENT_ID);
+    expect(result.data.messages.length).toBe(2);
+  });
+
+  test('slice <session>:<agent> has structured output with session_id and agent_id', async () => {
+    const { exitCode, stdout } = await runCli(['slice', `${SESSION_ID}:${SUBAGENT_ID}`, '--project', FAKE_PROJECT, '--turn', '1-2']);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.session_id).toBe(SESSION_ID);
+    expect(result.data.agent_id).toBe(SUBAGENT_ID);
+    expect(result.data.entries.length).toBe(2);
+  });
+
+  test('tokens <session>:<agent> works with agent_id', async () => {
+    const { exitCode, stdout } = await runCli(['tokens', `${SESSION_ID}:${SUBAGENT_ID}`, '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.session_id).toBe(SESSION_ID);
+    expect(result.data.agent_id).toBe(SUBAGENT_ID);
+  });
+
+  test('files <session>:<agent> works with agent_id', async () => {
+    const { exitCode, stdout } = await runCli(['files', `${SESSION_ID}:${SUBAGENT_ID}`, '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.session_id).toBe(SESSION_ID);
+    expect(result.data.agent_id).toBe(SUBAGENT_ID);
+  });
+
+  test('slug-based resolution with colon notation works', async () => {
+    const { exitCode, stdout } = await runCli(['shape', `multi-block-test:${SUBAGENT_ID}`, '--project', FAKE_PROJECT]);
+    // multi-block-test slug resolves to SESSION_ID_3 which has no subagents dir,
+    // so this should fail with NOT_FOUND
+    expect(exitCode).toBe(3);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe('NOT_FOUND');
+    expect(result.error.message).toContain('No subagent');
+  });
+});
+
+// ============================================================================
+// list --include-subagents integration tests
+// ============================================================================
+
+describe('list --include-subagents integration', () => {
+  test('includes subagent_count on all sessions when flag is set', async () => {
+    const { exitCode, stdout } = await runCli(['list', '--project', FAKE_PROJECT, '--include-subagents']);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    // Every session should have subagent_count field
+    for (const session of result.data) {
+      expect('subagent_count' in session).toBe(true);
+      expect(typeof session.subagent_count).toBe('number');
+    }
+    // SESSION_ID has 2 subagent JSONL files in its subagents directory
+    const sessionWithSubagents = result.data.find((s: any) => s.session_id === SESSION_ID);
+    expect(sessionWithSubagents).toBeDefined();
+    expect(sessionWithSubagents.subagent_count).toBe(2);
+    // Sessions without subagents directory should have count 0
+    const sessionWithout = result.data.find((s: any) => s.session_id === SESSION_ID_2);
+    expect(sessionWithout).toBeDefined();
+    expect(sessionWithout.subagent_count).toBe(0);
+  });
+
+  test('omits subagent_count entirely when flag is not set', async () => {
+    const { exitCode, stdout } = await runCli(['list', '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.length).toBeGreaterThan(0);
+    // No session should have subagent_count field
+    for (const session of result.data) {
+      expect('subagent_count' in session).toBe(false);
+    }
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -67,6 +67,7 @@ export type ListSession = {
   version: string | null;
   lines: number;
   slug: string | null;
+  subagent_count?: number;
 };
 
 export type ShapeRow = {
@@ -79,6 +80,7 @@ export type ShapeRow = {
 
 export type ShapeResult = {
   session_id: string;
+  agent_id: string | null;
   turns: ShapeRow[];
   summary: {
     total_turns: number;
@@ -99,6 +101,7 @@ export type ToolCall = {
 
 export type ToolsResult = {
   session_id: string;
+  agent_id: string | null;
   tool_calls: ToolCall[];
 };
 
@@ -112,6 +115,7 @@ export type TokenTurn = {
 
 export type TokensResult = {
   session_id: string;
+  agent_id: string | null;
   turns: TokenTurn[];
   totals: {
     input: number;
@@ -143,9 +147,29 @@ export type FileEntry = {
 
 export type FilesResult = {
   session_id: string;
+  agent_id: string | null;
   group_by: 'file' | 'turn';
   files?: FileEntry[];
   accesses?: FileAccess[];
+};
+
+export type ResolvedFile = {
+  filePath: string;
+  sessionId: string;      // parent session UUID
+  agentId: string | null;  // non-null when targeting a subagent
+};
+
+export type SubagentInfo = {
+  agent_id: string;
+  agent_type: string | null;
+  description: string | null;
+  lines: number;
+  timestamp: string | null;
+};
+
+export type SubagentsResult = {
+  session_id: string;
+  subagents: SubagentInfo[];
 };
 
 export type SearchMatch = {
@@ -254,16 +278,9 @@ export function resolveClaudeProjectDir(projectPath: string): string {
 
 /**
  * Resolve a session file from a UUID, UUID prefix, or slug.
- * Validates input against path traversal.
+ * Returns the full absolute path to the .jsonl file.
  */
-export async function resolveSessionFile(claudeDir: string, input: string): Promise<string> {
-  if (!input) {
-    throw cliError('INVALID_ARGS', 'Session ID is required');
-  }
-  if (!/^[a-zA-Z0-9-]+$/.test(input)) {
-    throw cliError('INVALID_ID', 'Invalid session ID -- only alphanumeric characters and hyphens allowed');
-  }
-
+async function resolveByIdOrSlug(claudeDir: string, input: string): Promise<string> {
   // Try UUID/prefix match
   const files = readdirSync(claudeDir).filter(f => f.endsWith('.jsonl') && f.startsWith(input));
   if (files.length === 1) return join(claudeDir, files[0]!);
@@ -292,6 +309,48 @@ export async function resolveSessionFile(claudeDir: string, input: string): Prom
   }
 
   throw cliError('NOT_FOUND', `No session found matching '${input}'`);
+}
+
+/**
+ * Resolve a session file from a UUID, UUID prefix, slug, or colon notation (session:agent-id).
+ * Validates input against path traversal.
+ */
+export async function resolveSessionFile(claudeDir: string, input: string): Promise<ResolvedFile> {
+  if (!input) {
+    throw cliError('INVALID_ARGS', 'Session ID is required');
+  }
+
+  // Check for colon notation: <session>:<agent-id>
+  const colonIdx = input.indexOf(':');
+  if (colonIdx !== -1) {
+    const sessionPart = input.slice(0, colonIdx);
+    const agentId = input.slice(colonIdx + 1);
+
+    // Validate each part independently
+    if (!/^[a-zA-Z0-9-]+$/.test(sessionPart)) {
+      throw cliError('INVALID_ID', 'Invalid session ID portion');
+    }
+    if (!/^[a-zA-Z0-9_-]+$/.test(agentId)) {
+      throw cliError('INVALID_ID', 'Invalid agent ID -- only alphanumeric characters, hyphens, and underscores allowed');
+    }
+
+    // Resolve parent session to get its UUID
+    const parentFile = await resolveByIdOrSlug(claudeDir, sessionPart);
+    const parentUuid = basename(parentFile, '.jsonl');
+    const subagentFile = join(claudeDir, parentUuid, 'subagents', `agent-${agentId}.jsonl`);
+
+    if (!existsSync(subagentFile)) {
+      throw cliError('NOT_FOUND', `No subagent '${agentId}' found for session '${parentUuid}'`);
+    }
+    return { filePath: subagentFile, sessionId: parentUuid, agentId };
+  }
+
+  // Non-subagent: existing resolution logic
+  if (!/^[a-zA-Z0-9-]+$/.test(input)) {
+    throw cliError('INVALID_ID', 'Invalid session ID -- only alphanumeric characters and hyphens allowed');
+  }
+  const filePath = await resolveByIdOrSlug(claudeDir, input);
+  return { filePath, sessionId: basename(filePath, '.jsonl'), agentId: null };
 }
 
 /** Parse a JSONL session file into an array of entries. Skips malformed lines. */
@@ -323,19 +382,19 @@ export function userAssistantEntries(entries: SessionEntry[]): SessionEntry[] {
   return entries.filter(e => e.type === 'user' || e.type === 'assistant');
 }
 
-/** Resolve a session from CLI args, returning the session ID and filtered entries. */
+/** Resolve a session from CLI args, returning the session ID, agent ID, and filtered entries. */
 export type ResolvedSession = {
   sessionId: string;
+  agentId: string | null;
   entries: SessionEntry[];
 };
 
 export async function resolveSession(args: { session: string; project?: string }): Promise<ResolvedSession> {
   const claudeDir = resolveClaudeProjectDir(args.project || process.cwd());
-  const sessionFile = await resolveSessionFile(claudeDir, args.session);
-  const sessionId = basename(sessionFile, '.jsonl');
-  const allEntries = await parseSessionLines(sessionFile);
+  const { filePath, sessionId, agentId } = await resolveSessionFile(claudeDir, args.session);
+  const allEntries = await parseSessionLines(filePath);
   const entries = userAssistantEntries(allEntries);
-  return { sessionId, entries };
+  return { sessionId, agentId, entries };
 }
 
 /** Parse turn range "N" or "N-M". Returns {start, end}. */
@@ -509,6 +568,47 @@ export function extractSessionMetadata(text: string): SessionMetadata {
   return { branch, timestamp, version, slug };
 }
 
+/** List subagents for a given session. Returns [] if no subagents directory exists. */
+export async function listSubagents(claudeDir: string, sessionUuid: string): Promise<SubagentInfo[]> {
+  if (!/^[a-zA-Z0-9-]+$/.test(sessionUuid)) {
+    throw cliError('INVALID_ID', 'Invalid session UUID');
+  }
+  const dir = join(claudeDir, sessionUuid, 'subagents');
+  if (!existsSync(dir)) return [];
+
+  const files = readdirSync(dir).filter(f => f.startsWith('agent-') && f.endsWith('.jsonl'));
+  const infos = await Promise.all(files.map(async (f) => {
+    const agentId = f.replace(/^agent-/, '').replace(/\.jsonl$/, '');
+    const jsonlPath = join(dir, f);
+    const metaPath = join(dir, f.replace('.jsonl', '.meta.json'));
+
+    let agentType: string | null = null;
+    let description: string | null = null;
+    try {
+      const meta = JSON.parse(await Bun.file(metaPath).text());
+      agentType = meta.agentType ?? null;
+      description = meta.description ?? null;
+    } catch { /* no meta file */ }
+
+    // Single read for both metadata extraction and line counting
+    const text = await Bun.file(jsonlPath).text();
+    const { timestamp } = extractSessionMetadata(text.slice(0, 8192));
+    const lines = text.split('\n').filter(l => l.trim()).length;
+
+    return { agent_id: agentId, agent_type: agentType, description, lines, timestamp };
+  }));
+
+  // Sort by timestamp descending (newest first), matching `list` command convention.
+  // Null timestamps sort to end.
+  infos.sort((a, b) => {
+    if (!a.timestamp && !b.timestamp) return 0;
+    if (!a.timestamp) return 1;
+    if (!b.timestamp) return -1;
+    return b.timestamp.localeCompare(a.timestamp);
+  });
+  return infos;
+}
+
 /** Result info for a tool_use_id, extracted from tool_result blocks. */
 export type ToolResultInfo = {
   is_error: boolean;
@@ -549,6 +649,7 @@ const listCommand = defineCommand({
     since: { type: 'string', description: 'Sessions from the last duration (e.g. 1d, 2h, 1w)' },
     last: { type: 'string', description: 'Return only the last N sessions' },
     'min-lines': { type: 'string', description: 'Sessions with at least N lines' },
+    'include-subagents': { type: 'boolean', description: 'Include subagent count per session', default: false },
   },
   async run({ args }) {
     try {
@@ -593,7 +694,16 @@ const listCommand = defineCommand({
               if (!timestamp || timestamp > args.before) return null;
             }
 
-            return { session_id: sessionId, branch, timestamp, version, lines: lineCount, slug } as ListSession;
+            const session: ListSession = { session_id: sessionId, branch, timestamp, version, lines: lineCount, slug };
+            if (args['include-subagents']) {
+              const subagentDir = join(claudeDir, sessionId, 'subagents');
+              if (existsSync(subagentDir)) {
+                session.subagent_count = readdirSync(subagentDir).filter(sf => sf.startsWith('agent-') && sf.endsWith('.jsonl')).length;
+              } else {
+                session.subagent_count = 0;
+              }
+            }
+            return session;
           } catch {
             return null; // skip unreadable files
           }
@@ -632,7 +742,7 @@ const tokensCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { sessionId, entries } = await resolveSession(args);
+      const { sessionId, agentId, entries } = await resolveSession(args);
 
       const turns: TokenTurn[] = [];
       let turnNum = 0;
@@ -669,7 +779,7 @@ const tokensCommand = defineCommand({
         });
       }
 
-      const result: TokensResult = { session_id: sessionId, turns: finalTurns, totals };
+      const result: TokensResult = { session_id: sessionId, agent_id: agentId, turns: finalTurns, totals };
       output(success(result, meta(turns.length, turns.length)));
     } catch (err: unknown) {
       handleCommandError(err);
@@ -689,7 +799,7 @@ const shapeCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { sessionId, entries } = await resolveSession(args);
+      const { sessionId, agentId, entries } = await resolveSession(args);
 
       const rows: ShapeRow[] = [];
       const toolCounts: Record<string, number> = {};
@@ -763,6 +873,7 @@ const shapeCommand = defineCommand({
 
       const result: ShapeResult = {
         session_id: sessionId,
+        agent_id: agentId,
         turns: rows,
         summary: {
           total_turns: turnNum,
@@ -794,7 +905,7 @@ const toolsCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { sessionId, entries } = await resolveSession(args);
+      const { sessionId, agentId, entries } = await resolveSession(args);
 
       const turnRange = args.turn ? parseTurnRange(args.turn) : null;
 
@@ -832,7 +943,7 @@ const toolsCommand = defineCommand({
       if (turnRange) calls = calls.filter(c => c.turn >= turnRange.start && c.turn <= turnRange.end);
 
       const total = calls.length;
-      const result: ToolsResult = { session_id: sessionId, tool_calls: calls };
+      const result: ToolsResult = { session_id: sessionId, agent_id: agentId, tool_calls: calls };
       output(success(result, meta(total, total)));
     } catch (err: unknown) {
       handleCommandError(err);
@@ -855,7 +966,7 @@ const filesCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { sessionId, entries } = await resolveSession(args);
+      const { sessionId, agentId, entries } = await resolveSession(args);
 
       const groupBy = args['group-by'] ?? 'file';
       if (groupBy !== 'file' && groupBy !== 'turn') {
@@ -897,7 +1008,7 @@ const filesCommand = defineCommand({
       if (opFilter) accesses = accesses.filter(a => a.operation === opFilter);
 
       if (groupBy === 'turn') {
-        const result: FilesResult = { session_id: sessionId, group_by: 'turn', accesses };
+        const result: FilesResult = { session_id: sessionId, agent_id: agentId, group_by: 'turn', accesses };
         output(success(result, meta(accesses.length, accesses.length)));
       } else {
         const fileMap = new Map<string, FileEntry>();
@@ -917,7 +1028,7 @@ const filesCommand = defineCommand({
         }
         const files = Array.from(fileMap.values());
         files.sort((a, b) => (a.turns[0] ?? 0) - (b.turns[0] ?? 0));
-        const result: FilesResult = { session_id: sessionId, group_by: 'file', files };
+        const result: FilesResult = { session_id: sessionId, agent_id: agentId, group_by: 'file', files };
         output(success(result, meta(files.length, files.length)));
       }
     } catch (err: unknown) {
@@ -942,7 +1053,7 @@ const messagesCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { entries } = await resolveSession(args);
+      const { sessionId, agentId, entries } = await resolveSession(args);
 
       const maxContent = parseIntArg(args['max-content'], '--max-content') ?? 200;
       const turnRange = args.turn ? parseTurnRange(args.turn) : null;
@@ -1009,7 +1120,7 @@ const messagesCommand = defineCommand({
         messages.push({ n: turnNum, role: entry.type as 'user' | 'assistant', content: processed as ContentBlock[] });
       }
 
-      output(success(messages, meta(messages.length, messages.length)));
+      output(success({ session_id: sessionId, agent_id: agentId, messages }, meta(messages.length, messages.length)));
     } catch (err: unknown) {
       handleCommandError(err);
     }
@@ -1030,7 +1141,7 @@ const sliceCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { entries } = await resolveSession(args);
+      const { sessionId, agentId, entries } = await resolveSession(args);
 
       const turnRange = parseTurnRange(args.turn);
       const maxContent = parseIntArg(args['max-content'], '--max-content');
@@ -1052,7 +1163,7 @@ const sliceCommand = defineCommand({
         }
       }
 
-      output(success(sliced, meta(sliced.length, sliced.length)));
+      output(success({ session_id: sessionId, agent_id: agentId, entries: sliced }, meta(sliced.length, sliced.length)));
     } catch (err: unknown) {
       handleCommandError(err);
     }
@@ -1257,6 +1368,33 @@ const searchCommand = defineCommand({
 });
 
 // ============================================================================
+// Subagents Command
+// ============================================================================
+
+const subagentsCommand = defineCommand({
+  meta: { name: 'subagents', description: 'List subagents for a session' },
+  args: {
+    session: { type: 'positional', description: 'Parent session ID', required: true },
+    project: { type: 'string', description: 'Absolute project path (defaults to CWD)' },
+  },
+  async run({ args }) {
+    try {
+      // Reject colon notation — subagents of subagents don't exist
+      if (args.session.includes(':')) {
+        throw cliError('INVALID_ARGS', 'subagents command takes a parent session ID, not a subagent reference');
+      }
+      const claudeDir = resolveClaudeProjectDir(args.project || process.cwd());
+      const { sessionId } = await resolveSessionFile(claudeDir, args.session);
+      const subagents = await listSubagents(claudeDir, sessionId);
+      const result: SubagentsResult = { session_id: sessionId, subagents };
+      output(success(result, meta(subagents.length, subagents.length)));
+    } catch (err: unknown) {
+      handleCommandError(err);
+    }
+  },
+});
+
+// ============================================================================
 // Main
 // ============================================================================
 
@@ -1275,6 +1413,7 @@ const main = defineCommand({
     slice: sliceCommand,
     files: filesCommand,
     search: searchCommand,
+    subagents: subagentsCommand,
   },
 });
 

--- a/index.ts
+++ b/index.ts
@@ -159,6 +159,18 @@ export type ResolvedFile = {
   agentId: string | null;  // non-null when targeting a subagent
 };
 
+export type MessagesResult = {
+  session_id: string;
+  agent_id: string | null;
+  messages: MessageEntry[];
+};
+
+export type SliceResult = {
+  session_id: string;
+  agent_id: string | null;
+  entries: SessionEntry[];
+};
+
 export type SubagentInfo = {
   agent_id: string;
   agent_type: string | null;
@@ -172,6 +184,7 @@ export type SubagentsResult = {
   subagents: SubagentInfo[];
 };
 
+// SearchMatch intentionally omits agent_id — it operates at the session-listing level, not session-scoped.
 export type SearchMatch = {
   session_id: string;
   branch: string | null;
@@ -328,7 +341,7 @@ export async function resolveSessionFile(claudeDir: string, input: string): Prom
 
     // Validate each part independently
     if (!/^[a-zA-Z0-9-]+$/.test(sessionPart)) {
-      throw cliError('INVALID_ID', 'Invalid session ID portion');
+      throw cliError('INVALID_ID', 'Invalid session ID portion -- only alphanumeric characters and hyphens allowed');
     }
     if (!/^[a-zA-Z0-9_-]+$/.test(agentId)) {
       throw cliError('INVALID_ID', 'Invalid agent ID -- only alphanumeric characters, hyphens, and underscores allowed');
@@ -568,6 +581,8 @@ export function extractSessionMetadata(text: string): SessionMetadata {
   return { branch, timestamp, version, slug };
 }
 
+const isSubagentFile = (f: string) => f.startsWith('agent-') && f.endsWith('.jsonl');
+
 /** List subagents for a given session. Returns [] if no subagents directory exists. */
 export async function listSubagents(claudeDir: string, sessionUuid: string): Promise<SubagentInfo[]> {
   if (!/^[a-zA-Z0-9-]+$/.test(sessionUuid)) {
@@ -576,9 +591,10 @@ export async function listSubagents(claudeDir: string, sessionUuid: string): Pro
   const dir = join(claudeDir, sessionUuid, 'subagents');
   if (!existsSync(dir)) return [];
 
-  const files = readdirSync(dir).filter(f => f.startsWith('agent-') && f.endsWith('.jsonl'));
-  const infos = await Promise.all(files.map(async (f) => {
+  const files = readdirSync(dir).filter(isSubagentFile);
+  const results = await Promise.all(files.map(async (f) => {
     const agentId = f.replace(/^agent-/, '').replace(/\.jsonl$/, '');
+    if (!/^[a-zA-Z0-9_-]+$/.test(agentId)) return null;
     const jsonlPath = join(dir, f);
     const metaPath = join(dir, f.replace('.jsonl', '.meta.json'));
 
@@ -586,17 +602,27 @@ export async function listSubagents(claudeDir: string, sessionUuid: string): Pro
     let description: string | null = null;
     try {
       const meta = JSON.parse(await Bun.file(metaPath).text());
-      agentType = meta.agentType ?? null;
-      description = meta.description ?? null;
-    } catch { /* no meta file */ }
+      agentType = typeof meta.agentType === 'string' ? meta.agentType : null;
+      description = typeof meta.description === 'string' ? meta.description : null;
+    } catch (err: unknown) {
+      if (!(err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT')) {
+        throw cliError('FORMAT_ERROR', `Failed to read metadata for subagent '${agentId}': ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
 
-    // Single read for both metadata extraction and line counting
-    const text = await Bun.file(jsonlPath).text();
+    // Single JSONL read for both metadata extraction and line counting
+    let text: string;
+    try {
+      text = await Bun.file(jsonlPath).text();
+    } catch (err: unknown) {
+      throw cliError('FORMAT_ERROR', `Failed to read subagent file '${agentId}': ${err instanceof Error ? err.message : String(err)}`);
+    }
     const { timestamp } = extractSessionMetadata(text.slice(0, 8192));
     const lines = text.split('\n').filter(l => l.trim()).length;
 
     return { agent_id: agentId, agent_type: agentType, description, lines, timestamp };
   }));
+  const infos = results.filter((info): info is SubagentInfo => info !== null);
 
   // Sort by timestamp descending (newest first), matching `list` command convention.
   // Null timestamps sort to end.
@@ -696,10 +722,14 @@ const listCommand = defineCommand({
 
             const session: ListSession = { session_id: sessionId, branch, timestamp, version, lines: lineCount, slug };
             if (args['include-subagents']) {
-              const subagentDir = join(claudeDir, sessionId, 'subagents');
-              if (existsSync(subagentDir)) {
-                session.subagent_count = readdirSync(subagentDir).filter(sf => sf.startsWith('agent-') && sf.endsWith('.jsonl')).length;
-              } else {
+              try {
+                const subagentDir = join(claudeDir, sessionId, 'subagents');
+                if (existsSync(subagentDir)) {
+                  session.subagent_count = readdirSync(subagentDir).filter(isSubagentFile).length;
+                } else {
+                  session.subagent_count = 0;
+                }
+              } catch {
                 session.subagent_count = 0;
               }
             }
@@ -1120,7 +1150,8 @@ const messagesCommand = defineCommand({
         messages.push({ n: turnNum, role: entry.type as 'user' | 'assistant', content: processed as ContentBlock[] });
       }
 
-      output(success({ session_id: sessionId, agent_id: agentId, messages }, meta(messages.length, messages.length)));
+      const result: MessagesResult = { session_id: sessionId, agent_id: agentId, messages };
+      output(success(result, meta(messages.length, messages.length)));
     } catch (err: unknown) {
       handleCommandError(err);
     }
@@ -1163,7 +1194,8 @@ const sliceCommand = defineCommand({
         }
       }
 
-      output(success({ session_id: sessionId, agent_id: agentId, entries: sliced }, meta(sliced.length, sliced.length)));
+      const result: SliceResult = { session_id: sessionId, agent_id: agentId, entries: sliced };
+      output(success(result, meta(sliced.length, sliced.length)));
     } catch (err: unknown) {
       handleCommandError(err);
     }


### PR DESCRIPTION
## Summary

Add support for querying subagent sessions. Claude Code stores subagent transcripts as JSONL files in `<session-dir>/subagents/agent-<agentId>.jsonl` with companion `.meta.json` metadata files.

- **Colon notation:** Any session-scoped command (`shape`, `tools`, `files`, `tokens`, `messages`, `slice`) can target a subagent via `<session>:<agent-id>` (e.g., `shape DA2738E3:a77e3eda9b0dd71f8`)
- **`subagents` command:** Lists subagents for a parent session with metadata from `.meta.json` (agent type, description, line count, timestamp)
- **`list --include-subagents`:** Opt-in flag adds `subagent_count` to each session in list output
- **`agent_id` in output:** All session-scoped result types include `agent_id: string | null` for identity round-tripping
- **Output restructuring:** `messages` and `slice` now return structured objects (`{ session_id, agent_id, messages/entries }`) instead of bare arrays

### Architecture

Session resolution is refactored through a single change point — `resolveSessionFile` returns a structured `ResolvedFile` (`{ filePath, sessionId, agentId }`) instead of a bare path string. An internal `resolveByIdOrSlug` helper handles UUID/prefix/slug matching. All downstream commands receive subagent context through the existing `resolveSession` pipeline without individual modifications.

### Breaking changes

- `resolveSessionFile` return type: `Promise<string>` → `Promise<ResolvedFile>`
- `ResolvedSession` gains `agentId: string | null`
- `messages` data: `MessageEntry[]` → `{ session_id, agent_id, messages }`
- `slice` data: `SessionEntry[]` → `{ session_id, agent_id, entries }`
- `ShapeResult`, `ToolsResult`, `TokensResult`, `FilesResult` gain required `agent_id` field

All acceptable for a pre-1.0 tool.

## Test plan

- [ ] `bun test` — 166 tests pass
- [ ] Verify colon notation: `bun run index.ts shape <session>:<agent> --project <path>`
- [ ] Verify `subagents` command: `bun run index.ts subagents <session> --project <path>`
- [ ] Verify `list --include-subagents`: `bun run index.ts list --include-subagents --project <path>`
- [ ] Verify `subagents` rejects colon notation: `bun run index.ts subagents <session>:<agent>` → exit code 2
- [ ] Verify backward compat: existing commands without colon notation unchanged