### PR TITLE
Fix slug resolution beyond initial read window

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,7 @@
+# Project-scoped Codex configuration for GetWyz.
+#
+# Codex loads this file only when the repository is trusted. Keep this file
+# focused on repo behavior; user-specific model/provider settings belong in
+# ~/.codex/config.toml.
+
+project_doc_fallback_filenames = ["CLAUDE.md"]

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,4 +1,4 @@
-# Project-scoped Codex configuration for GetWyz.
+# Project-scoped Codex configuration for cc-session-tool.
 #
 # Codex loads this file only when the repository is trusted. Keep this file
 # focused on repo behavior; user-specific model/provider settings belong in

--- a/index.test.ts
+++ b/index.test.ts
@@ -1287,6 +1287,15 @@ describe('extractSessionMetadata', () => {
     expect(meta.slug).toBe('my-cool-slug');
   });
 
+  test('can skip slug extraction', () => {
+    const header = JSON.stringify({ type: 'system', sessionId: 's1', gitBranch: 'dev', timestamp: '2025-01-01T00:00:00Z' });
+    const slugLine = JSON.stringify({ type: 'assistant', slug: 'my-cool-slug' });
+    const meta = extractSessionMetadata([header, slugLine].join('\n'), { includeSlug: false });
+    expect(meta.branch).toBe('dev');
+    expect(meta.timestamp).toBe('2025-01-01T00:00:00Z');
+    expect(meta.slug).toBeNull();
+  });
+
   test('returns null slug when no slug pattern exists', () => {
     const text = JSON.stringify({ type: 'system', sessionId: 's1', gitBranch: 'main', timestamp: '2025-01-01T00:00:00Z' });
     const meta = extractSessionMetadata(text);

--- a/index.test.ts
+++ b/index.test.ts
@@ -354,6 +354,15 @@ const SESSION_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 const SESSION_ID_2 = 'bbbbbbbb-1111-2222-3333-444444444444';
 const SESSION_ID_3 = 'cccccccc-1111-2222-3333-444444444444';
 const SESSION_ID_4 = 'dddddddd-1111-2222-3333-444444444444';
+const SESSION_ID_5 = 'eeeeeeee-1111-2222-3333-444444444444';
+const LATE_SLUG_FIRST_LINE = JSON.stringify({
+  type: 'user',
+  sessionId: SESSION_ID_5,
+  timestamp: '2026-03-05T10:00:00.000Z',
+  gitBranch: 'main',
+  version: '2.1.0',
+  message: { role: 'user', content: 'x'.repeat(8300) },
+});
 
 function makeFixtureLines(): string[] {
   const ts1 = '2026-03-01T10:00:00.000Z';
@@ -378,6 +387,7 @@ function makeFixtureLines(): string[] {
     JSON.stringify({
       type: 'assistant',
       timestamp: ts2,
+      slug: 'parent-subagent-test',
       message: {
         role: 'assistant',
         content: [
@@ -494,6 +504,26 @@ beforeAll(() => {
   writeFileSync(join(subagentDir, `agent-${subagent2Id}.jsonl`), subagent2Lines.join('\n') + '\n');
   // Intentionally no .meta.json for subagent2
 
+  // Third subagent fixture with metadata beyond the old 8192-byte extraction window.
+  const subagent3Id = 'c0583de';
+  const lateSubagentMetadataFirstLine = JSON.stringify({
+    type: 'summary',
+    summary: 'x'.repeat(8300),
+  });
+  const subagent3Lines = [
+    lateSubagentMetadataFirstLine,
+    JSON.stringify({
+      type: 'user',
+      sessionId: SESSION_ID,
+      timestamp: '2026-03-01T10:20:00.000Z',
+      gitBranch: 'main',
+      version: '2.1.0',
+      message: { role: 'user', content: 'Late metadata subagent task' },
+    }),
+  ];
+  expect(Buffer.byteLength(lateSubagentMetadataFirstLine)).toBeGreaterThan(8192);
+  writeFileSync(join(subagentDir, `agent-${subagent3Id}.jsonl`), subagent3Lines.join('\n') + '\n');
+
   // Second fixture with same slug for ambiguous slug tests
   const lines2 = [
     JSON.stringify({
@@ -564,6 +594,21 @@ beforeAll(() => {
     }),
   ];
   writeFileSync(join(CLAUDE_DIR, `${SESSION_ID_4}.jsonl`), lines4.join('\n') + '\n');
+
+  const lateSlugLines = [
+    LATE_SLUG_FIRST_LINE,
+    JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-03-05T10:01:00.000Z',
+      slug: 'late-slug-test',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Late slug response' }],
+        usage: { input_tokens: 40, output_tokens: 10 },
+      },
+    }),
+  ];
+  writeFileSync(join(CLAUDE_DIR, `${SESSION_ID_5}.jsonl`), lateSlugLines.join('\n') + '\n');
 });
 
 afterAll(() => {
@@ -596,7 +641,7 @@ describe('list integration', () => {
     expect(exitCode).toBe(0);
     const result = parseOutput(stdout);
     expect(result.ok).toBe(true);
-    expect(result.data.length).toBe(4);
+    expect(result.data.length).toBe(5);
     const session1 = result.data.find((s: any) => s.session_id === SESSION_ID);
     expect(session1).toBeDefined();
     expect(session1.branch).toBe('main');
@@ -630,8 +675,8 @@ describe('list integration', () => {
     const result = parseOutput(stdout);
     expect(result.ok).toBe(true);
     expect(result.data.length).toBe(1);
-    expect(result.data[0].session_id).toBe(SESSION_ID_4); // newest (2026-03-04)
-    expect(result._meta.total).toBe(4);
+    expect(result.data[0].session_id).toBe(SESSION_ID_5); // newest (2026-03-05)
+    expect(result._meta.total).toBe(5);
     expect(result._meta.returned).toBe(1);
     expect(result._meta.hasMore).toBe(true);
   });
@@ -645,7 +690,7 @@ describe('list integration', () => {
   test('--last larger than total returns all', async () => {
     const { stdout } = await runCli(['list', '--project', FAKE_PROJECT, '--last', '100']);
     const result = parseOutput(stdout);
-    expect(result.data.length).toBe(4);
+    expect(result.data.length).toBe(5);
     expect(result._meta.hasMore).toBe(false);
   });
 
@@ -662,7 +707,7 @@ describe('list integration', () => {
     expect(exitCode).toBe(0);
     const result = parseOutput(stdout);
     expect(result.ok).toBe(true);
-    expect(result.data.length).toBe(4);
+    expect(result.data.length).toBe(5);
   });
 
   test('--since and --after together returns error', async () => {
@@ -697,6 +742,24 @@ describe('shape integration', () => {
     expect(exitCode).toBe(0);
     const result = parseOutput(stdout);
     expect(result.data.session_id).toBe(SESSION_ID);
+  });
+
+  test('resolves session by ordinary unique slug', async () => {
+    const { exitCode, stdout } = await runCli(['shape', 'multi-block-test', '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.session_id).toBe(SESSION_ID_3);
+    expect(result.data.agent_id).toBeNull();
+  });
+
+  test('resolves session by late slug', async () => {
+    const { exitCode, stdout } = await runCli(['shape', 'late-slug-test', '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.session_id).toBe(SESSION_ID_5);
+    expect(result.data.agent_id).toBeNull();
   });
 
   test('ambiguous slug returns error', async () => {
@@ -934,6 +997,22 @@ describe('resolveSessionFile', () => {
     const result = await resolveSessionFile(CLAUDE_DIR, SESSION_ID);
     expect(result.filePath).toBe(join(CLAUDE_DIR, `${SESSION_ID}.jsonl`));
     expect(result.sessionId).toBe(SESSION_ID);
+    expect(result.agentId).toBeNull();
+  });
+
+  test('UUID prefix match resolves', async () => {
+    const result = await resolveSessionFile(CLAUDE_DIR, SESSION_ID_3.slice(0, 8));
+    expect(result.filePath).toBe(join(CLAUDE_DIR, `${SESSION_ID_3}.jsonl`));
+    expect(result.sessionId).toBe(SESSION_ID_3);
+    expect(result.agentId).toBeNull();
+  });
+
+  test('late slug after 8192 bytes resolves', async () => {
+    expect(Buffer.byteLength(LATE_SLUG_FIRST_LINE)).toBeGreaterThan(8192);
+
+    const result = await resolveSessionFile(CLAUDE_DIR, 'late-slug-test');
+    expect(result.filePath).toBe(join(CLAUDE_DIR, `${SESSION_ID_5}.jsonl`));
+    expect(result.sessionId).toBe(SESSION_ID_5);
     expect(result.agentId).toBeNull();
   });
 
@@ -1529,13 +1608,23 @@ describe('listSubagents', () => {
     expect(agent!.lines).toBe(2);
   });
 
+  test('extracts timestamp from subagent metadata after first 8192 bytes', async () => {
+    const result = await listSubagents(CLAUDE_DIR, SESSION_ID);
+    const agent = result.find(a => a.agent_id === 'c0583de');
+    expect(agent).toBeDefined();
+    expect(agent!.lines).toBe(2);
+    expect(agent!.timestamp).toBe('2026-03-01T10:20:00.000Z');
+  });
+
   test('results are sorted by timestamp descending (newest first)', async () => {
     const result = await listSubagents(CLAUDE_DIR, SESSION_ID);
-    expect(result.length).toBe(2);
+    expect(result.length).toBe(3);
+    // c0583de has timestamp 2026-03-01T10:20:00.000Z (newest)
     // a8361bc has timestamp 2026-03-01T10:10:00.000Z (newer)
     // b9472cd has timestamp 2026-03-01T10:05:00.000Z (older)
-    expect(result[0].agent_id).toBe('a8361bc');
-    expect(result[1].agent_id).toBe('b9472cd');
+    expect(result[0].agent_id).toBe('c0583de');
+    expect(result[1].agent_id).toBe('a8361bc');
+    expect(result[2].agent_id).toBe('b9472cd');
   });
 
   test('rejects invalid session UUID', async () => {
@@ -1559,7 +1648,7 @@ describe('subagents integration', () => {
     const result = parseOutput(stdout);
     expect(result.ok).toBe(true);
     expect(result.data.session_id).toBe(SESSION_ID);
-    expect(result.data.subagents.length).toBe(2);
+    expect(result.data.subagents.length).toBe(3);
     const agent = result.data.subagents.find((a: any) => a.agent_id === 'a8361bc');
     expect(agent).toBeDefined();
     expect(agent.agent_type).toBe('test-agent');
@@ -1659,6 +1748,16 @@ describe('colon notation integration', () => {
     expect(result.data.agent_id).toBe(SUBAGENT_ID);
   });
 
+  test('shape <slug>:<agent> resolves parent slug before subagent lookup', async () => {
+    const { exitCode, stdout } = await runCli(['shape', `parent-subagent-test:${SUBAGENT_ID}`, '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.session_id).toBe(SESSION_ID);
+    expect(result.data.agent_id).toBe(SUBAGENT_ID);
+    expect(result.data.summary.total_turns).toBe(2);
+  });
+
   test('slug-based resolution with colon notation works', async () => {
     const { exitCode, stdout } = await runCli(['shape', `multi-block-test:${SUBAGENT_ID}`, '--project', FAKE_PROJECT]);
     // multi-block-test slug resolves to SESSION_ID_3 which has no subagents dir,
@@ -1686,10 +1785,10 @@ describe('list --include-subagents integration', () => {
       expect('subagent_count' in session).toBe(true);
       expect(typeof session.subagent_count).toBe('number');
     }
-    // SESSION_ID has 2 subagent JSONL files in its subagents directory
+    // SESSION_ID has 3 subagent JSONL files in its subagents directory
     const sessionWithSubagents = result.data.find((s: any) => s.session_id === SESSION_ID);
     expect(sessionWithSubagents).toBeDefined();
-    expect(sessionWithSubagents.subagent_count).toBe(2);
+    expect(sessionWithSubagents.subagent_count).toBe(3);
     // Sessions without subagents directory should have count 0
     const sessionWithout = result.data.find((s: any) => s.session_id === SESSION_ID_2);
     expect(sessionWithout).toBeDefined();

--- a/index.ts
+++ b/index.ts
@@ -295,21 +295,19 @@ export function resolveClaudeProjectDir(projectPath: string): string {
  */
 async function resolveByIdOrSlug(claudeDir: string, input: string): Promise<string> {
   // Try UUID/prefix match
-  const files = readdirSync(claudeDir).filter(f => f.endsWith('.jsonl') && f.startsWith(input));
-  if (files.length === 1) return join(claudeDir, files[0]!);
-  if (files.length > 1) {
-    throw cliError('INVALID_ID', `Ambiguous session ID prefix '${input}' -- matches ${files.length} sessions`);
+  const allFiles = readdirSync(claudeDir).filter(f => f.endsWith('.jsonl'));
+  const prefixMatches = allFiles.filter(f => f.startsWith(input));
+  if (prefixMatches.length === 1) return join(claudeDir, prefixMatches[0]!);
+  if (prefixMatches.length > 1) {
+    throw cliError('INVALID_ID', `Ambiguous session ID prefix '${input}' -- matches ${prefixMatches.length} sessions`);
   }
 
-  // Try slug match - search for "slug":"<input>" in all jsonl files
-  const allFiles = readdirSync(claudeDir).filter(f => f.endsWith('.jsonl'));
-  const slugPattern = `"slug":"${input}"`;
+  // Try slug match in all JSONL files after UUID/prefix matching fails.
   const slugMatches: string[] = [];
   for (const f of allFiles) {
+    const filePath = join(claudeDir, f);
     try {
-      const filePath = join(claudeDir, f);
-      const chunk = await Bun.file(filePath).slice(0, 8192).text();
-      if (chunk.includes(slugPattern)) {
+      if (await fileContainsSlug(filePath, input)) {
         slugMatches.push(filePath);
       }
     } catch {
@@ -322,6 +320,29 @@ async function resolveByIdOrSlug(claudeDir: string, input: string): Promise<stri
   }
 
   throw cliError('NOT_FOUND', `No session found matching '${input}'`);
+}
+
+async function fileContainsSlug(filePath: string, slug: string): Promise<boolean> {
+  const slugNeedle = `"slug":"${slug}"`;
+  const text = await Bun.file(filePath).text();
+
+  for (const line of text.split('\n')) {
+    if (!line.includes(slugNeedle)) continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        (parsed as SessionEntry).slug === slug
+      ) {
+        return true;
+      }
+    } catch {
+      // skip malformed lines during slug matching
+    }
+  }
+
+  return false;
 }
 
 /**
@@ -617,7 +638,7 @@ export async function listSubagents(claudeDir: string, sessionUuid: string): Pro
     } catch (err: unknown) {
       throw cliError('FORMAT_ERROR', `Failed to read subagent file '${agentId}': ${err instanceof Error ? err.message : String(err)}`);
     }
-    const { timestamp } = extractSessionMetadata(text.slice(0, 8192));
+    const { timestamp } = extractSessionMetadata(text);
     const lines = text.split('\n').filter(l => l.trim()).length;
 
     return { agent_id: agentId, agent_type: agentType, description, lines, timestamp };

--- a/index.ts
+++ b/index.ts
@@ -355,7 +355,11 @@ async function fileContainsSlug(filePath: string, slug: string): Promise<boolean
         const line = buffered.slice(0, newlineIndex);
         buffered = buffered.slice(newlineIndex + 1);
         if (matchesSlug(line)) {
-          await reader.cancel();
+          try {
+            await reader.cancel();
+          } catch {
+            // A cleanup failure should not change a confirmed slug match.
+          }
           return true;
         }
         newlineIndex = buffered.indexOf('\n');

--- a/index.ts
+++ b/index.ts
@@ -605,19 +605,24 @@ export function extractSessionMetadata(text: string): SessionMetadata {
   let version: string | null = null;
   let slug: string | null = null;
 
-  const lines = text.split('\n');
-  for (let j = 0; j < Math.min(5, lines.length); j++) {
-    const rawLine = lines[j];
-    if (!rawLine?.trim()) continue;
-    try {
-      const entry = JSON.parse(rawLine);
-      if (entry.sessionId) {
-        branch = entry.gitBranch ?? null;
-        version = entry.version ?? null;
-        timestamp = entry.timestamp ?? null;
-        break;
-      }
-    } catch { /* skip */ }
+  let lineStart = 0;
+  for (let j = 0; j < 5 && lineStart <= text.length; j++) {
+    const newlineIndex = text.indexOf('\n', lineStart);
+    const lineEnd = newlineIndex === -1 ? text.length : newlineIndex;
+    const rawLine = text.slice(lineStart, lineEnd);
+    if (rawLine.trim()) {
+      try {
+        const entry = JSON.parse(rawLine);
+        if (entry.sessionId) {
+          branch = entry.gitBranch ?? null;
+          version = entry.version ?? null;
+          timestamp = entry.timestamp ?? null;
+          break;
+        }
+      } catch { /* skip */ }
+    }
+    if (newlineIndex === -1) break;
+    lineStart = newlineIndex + 1;
   }
 
   const slugMatch = text.match(/"slug":"([a-zA-Z0-9][a-zA-Z0-9-]*)"/);
@@ -627,6 +632,23 @@ export function extractSessionMetadata(text: string): SessionMetadata {
 }
 
 const isSubagentFile = (f: string) => f.startsWith('agent-') && f.endsWith('.jsonl');
+
+function countNonEmptyLines(text: string): number {
+  let count = 0;
+  let lineHasContent = false;
+
+  for (const char of text) {
+    if (char === '\n') {
+      if (lineHasContent) count++;
+      lineHasContent = false;
+    } else if (char.trim() !== '') {
+      lineHasContent = true;
+    }
+  }
+
+  if (lineHasContent) count++;
+  return count;
+}
 
 /** List subagents for a given session. Returns [] if no subagents directory exists. */
 export async function listSubagents(claudeDir: string, sessionUuid: string): Promise<SubagentInfo[]> {
@@ -663,7 +685,7 @@ export async function listSubagents(claudeDir: string, sessionUuid: string): Pro
       throw cliError('FORMAT_ERROR', `Failed to read subagent file '${agentId}': ${err instanceof Error ? err.message : String(err)}`);
     }
     const { timestamp } = extractSessionMetadata(text);
-    const lines = text.split('\n').filter(l => l.trim()).length;
+    const lines = countNonEmptyLines(text);
 
     return { agent_id: agentId, agent_type: agentType, description, lines, timestamp };
   }));

--- a/index.ts
+++ b/index.ts
@@ -324,25 +324,49 @@ async function resolveByIdOrSlug(claudeDir: string, input: string): Promise<stri
 
 async function fileContainsSlug(filePath: string, slug: string): Promise<boolean> {
   const slugNeedle = `"slug":"${slug}"`;
-  const text = await Bun.file(filePath).text();
+  const stream = Bun.file(filePath).stream();
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffered = '';
 
-  for (const line of text.split('\n')) {
-    if (!line.includes(slugNeedle)) continue;
+  const matchesSlug = (line: string): boolean => {
+    if (!line.includes(slugNeedle)) return false;
     try {
       const parsed: unknown = JSON.parse(line);
-      if (
+      return (
         typeof parsed === 'object' &&
         parsed !== null &&
         (parsed as SessionEntry).slug === slug
-      ) {
-        return true;
-      }
+      );
     } catch {
       // skip malformed lines during slug matching
+      return false;
     }
+  };
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+
+      buffered += decoder.decode(value, { stream: true });
+      let newlineIndex = buffered.indexOf('\n');
+      while (newlineIndex !== -1) {
+        const line = buffered.slice(0, newlineIndex);
+        buffered = buffered.slice(newlineIndex + 1);
+        if (matchesSlug(line)) {
+          await reader.cancel();
+          return true;
+        }
+        newlineIndex = buffered.indexOf('\n');
+      }
+    }
+    buffered += decoder.decode();
+  } finally {
+    reader.releaseLock();
   }
 
-  return false;
+  return buffered.length > 0 && matchesSlug(buffered);
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -603,7 +603,12 @@ export type SessionMetadata = {
   slug: string | null;
 };
 
-export function extractSessionMetadata(text: string): SessionMetadata {
+type ExtractSessionMetadataOptions = {
+  includeSlug?: boolean;
+};
+
+export function extractSessionMetadata(text: string, options: ExtractSessionMetadataOptions = {}): SessionMetadata {
+  const includeSlug = options.includeSlug ?? true;
   let branch: string | null = null;
   let timestamp: string | null = null;
   let version: string | null = null;
@@ -629,8 +634,10 @@ export function extractSessionMetadata(text: string): SessionMetadata {
     lineStart = newlineIndex + 1;
   }
 
-  const slugMatch = text.match(/"slug":"([a-zA-Z0-9][a-zA-Z0-9-]*)"/);
-  if (slugMatch) slug = slugMatch[1] ?? null;
+  if (includeSlug) {
+    const slugMatch = text.match(/"slug":"([a-zA-Z0-9][a-zA-Z0-9-]*)"/);
+    if (slugMatch) slug = slugMatch[1] ?? null;
+  }
 
   return { branch, timestamp, version, slug };
 }
@@ -688,7 +695,7 @@ export async function listSubagents(claudeDir: string, sessionUuid: string): Pro
     } catch (err: unknown) {
       throw cliError('FORMAT_ERROR', `Failed to read subagent file '${agentId}': ${err instanceof Error ? err.message : String(err)}`);
     }
-    const { timestamp } = extractSessionMetadata(text);
+    const { timestamp } = extractSessionMetadata(text, { includeSlug: false });
     const lines = countNonEmptyLines(text);
 
     return { agent_id: agentId, agent_type: agentType, description, lines, timestamp };


### PR DESCRIPTION
## Summary
- Replace the 8KB slug lookup window with full-file JSONL line scanning and exact top-level slug validation
- Preserve UUID/prefix precedence and ambiguous slug behavior
- Pass full subagent JSONL text into metadata extraction
- Add regression coverage for late slugs, CLI slug resolution, slug-based subagent targeting, and late subagent metadata

## Verification
- bun test
- Manual CLI verification against real project session data: list sessions, identify slugs beyond the old 8KB window, and resolve late slugs with shape