### PR TITLE
Improve agent workflows for session search, triage, and audits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,14 +27,16 @@ Default to Bun instead of Node.js:
 
 ## Architecture
 
-Single-file CLI (`index.ts`) using `citty` for command parsing. All types, helpers, and commands live in one file. Types and pure helpers are `export`ed for unit testing.
+CLI entrypoint and command wiring live in `index.ts` using `citty`. Shared transcript, project-selection, and search primitives live under `src/` and are exported for unit testing.
 
 ### Subcommands
 
 | Command | Purpose |
 |---------|---------|
-| `list` | Index sessions with metadata; supports `--all-projects --project-glob` for audits |
+| `list` | Index sessions with metadata; scoped lists include associated Claude worktrees by default and support `--main-only` |
+| `projects` | Summarize Claude project transcript directories and expose raw project handles |
 | `shape` | Turn-by-turn skeleton with summary stats (tool counts, duration, first edit) |
+| `summary` | One-call triage summary for a session |
 | `tools` | Tool call log with condensed input summaries and outcomes |
 | `files` | Files touched in a session, grouped by path or turn |
 | `tokens` | Per-turn token usage timeline (optional cumulative mode) |
@@ -43,15 +45,15 @@ Single-file CLI (`index.ts`) using `citty` for command parsing. All types, helpe
 | `search` | Find sessions matching structured queries (tool, input, file, text, bash filters), scoped to the logical project plus associated Claude worktrees by default |
 | `subagents` | List subagents for a session with metadata |
 
-All session-scoped commands accept a positional session identifier (UUID, UUID prefix, or slug) and an optional `--project` flag (defaults to CWD). They also accept `--claude-project <project>` for stable follow-up from search/list rows that expose raw Claude project basenames through `project` or `session_ref.project`; do not use `project_path_guess` as a follow-up handle. `--project` and `--claude-project` are mutually exclusive. Subagent sessions can be targeted using colon notation: `<session>:<agent-id>` (e.g., `DA2738E3:a8361bc`).
+All session-scoped commands accept a positional session identifier (UUID, UUID prefix, or slug) and an optional `--project` flag (defaults to CWD). They also accept `--claude-project <project>` for stable follow-up from search/list/projects rows that expose raw Claude project basenames through `project` or `session_ref.project`; do not use `project_path_guess` as a follow-up handle. `--project` and `--claude-project` are mutually exclusive. Subagent sessions can be targeted using colon notation: `<session>:<agent-id>` (e.g., `DA2738E3:a8361bc`).
 
-The `search` command is agent-first and worktree-aware by default. A scoped search from the logical project checkout includes associated Claude-managed worktree transcript directories and compares absolute main-tree file queries to worktree-local accesses by exact canonical path candidates first, then shared project-relative identity. Use `search --file <absolute-main-tree-path> --operation write` as the primary workflow for finding worktree writes to the same logical file; use `--all-projects` for broad audits, not routine worktree lookup.
+The `list` and `search` commands are agent-first and worktree-aware by default. A scoped query from the logical project checkout includes associated Claude-managed worktree transcript directories. Use `list --main-only` only when you intentionally want to ignore worktree sessions. Search compares absolute main-tree file queries to worktree-local accesses by exact canonical path candidates first, then shared project-relative identity. Use `search --file <absolute-main-tree-path> --operation write` as the primary workflow for finding worktree writes to the same logical file; use `--all-projects` for broad audits, not routine worktree lookup.
 
 In `search --all-projects`, an explicit `--project <path>` is a query identity anchor for absolute file matching only. It must not be treated as a scan limit, and without it the command must not silently use CWD or `project_path_guess` as the authoritative project root for unrelated projects.
 
 Use `search --file <path> --operation <read|edit|write|grep|glob>` to bind file-operation filtering to the same matching file access. Use `--origin` to return the earliest matching transcript write evidence for a file; this is transcript evidence, not VCS creation history. Use `--sort session-newest|match-earliest|match-newest|project` for deterministic ordering.
 
-Use `search --tool <name> --input-match <pattern>` to match raw structured tool inputs, including values omitted or truncated in `input_summary`. Add `--aggregate count-per-session` for per-session audit counts. `--project-glob` is valid only with `--all-projects` on `search` and `list`; it matches raw Claude project basenames and display-only `project_path_guess` strings, not filesystem files.
+Use `search --tool <name> --input-match <pattern>` or `tools --input-match <pattern>` to match raw structured tool inputs, including values omitted or truncated in `input_summary`. Add `--aggregate count-per-session` for per-session audit counts, or `--aggregate counters --counter name=pattern --bucket day|week` for named audit tables. `--project-glob` is valid only with `--all-projects` on `search` and `list`; it matches raw Claude project basenames and display-only `project_path_guess` strings, not filesystem files.
 
 ### Session Resolution
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All commands except `list` require a `<session>` argument. Three forms are accep
 | UUID prefix | `DA2738E3`                             | Prefix match (must be unambiguous)                     |
 | Slug        | `snuggly-floating-barto`               | Search across all `.jsonl` files (must be unambiguous) |
 
-All session commands accept `--project <path>` to specify the project directory (defaults to CWD). They also accept `--claude-project <project>` when you need to target a raw Claude project directory basename returned by `search` or `list --all-projects`. `--project` and `--claude-project` are mutually exclusive.
+All session commands accept `--project <path>` to specify the project directory (defaults to CWD). They also accept `--claude-project <project>` when you need to target a raw Claude project directory basename returned by `search`, `list`, or `projects`. `--project` and `--claude-project` are mutually exclusive.
 
 Use `--claude-project` for stable follow-up from cross-project or worktree search results:
 
@@ -56,17 +56,20 @@ All commands use consistent turn numbering:
 
 ### `list`
 
-Index all sessions by reading metadata from the first few lines of each file.
+Index sessions by reading metadata from the first few lines of each file. A scoped `list --project <repo>` includes the repo's associated Claude-managed worktree transcript directories by default, matching `search`; use `--main-only` to inspect only the main project transcript directory.
 
 ```bash
-cc-session-tool list [--project <path>] [--all-projects] [--project-glob <pattern>] [--branch <name>] [--after <date>] [--before <date>] [--since <duration>] [--last <n>] [--min-lines <n>] [--include-subagents]
+cc-session-tool list [--project <path>] [--main-only] [--all-projects] [--project-glob <pattern>] [--intent-match <text>|--intent-regex <regex>] [--branch <name>] [--after <date>] [--before <date>] [--since <duration>] [--last <n>] [--min-lines <n>] [--include-subagents]
 ```
 
 | Option        | Default | Description                                                    |
 | ------------- | ------- | -------------------------------------------------------------- |
 | `--branch`    | all     | Filter by git branch name                                      |
 | `--all-projects` | false | List sessions from every top-level Claude project directory under `~/.claude/projects`. |
+| `--main-only` | false | With scoped `--project`, skip associated Claude worktree transcript directories. Cannot be combined with `--all-projects`. |
 | `--project-glob` | —     | With `--all-projects`, filter by raw Claude project basename or display-only `project_path_guess`. Supports `*` and `?`. |
+| `--intent-match` | —     | Filter session intent sources (`slug`, first prompt token, first user message) by case-insensitive substring. |
+| `--intent-regex` | —     | Filter session intent sources by regex. Mutually exclusive with `--intent-match`. |
 | `--after`     | —       | Sessions after ISO 8601 date (mutually exclusive with `--since`) |
 | `--before`    | —       | Sessions before ISO 8601 date                                  |
 | `--since`     | —       | Sessions from the last duration: `30m`, `2h`, `1d`, `1w` (mutually exclusive with `--after`) |
@@ -74,7 +77,7 @@ cc-session-tool list [--project <path>] [--all-projects] [--project-glob <patter
 | `--min-lines` | 0       | Sessions with at least N lines                                 |
 | `--include-subagents` | false | Include `subagent_count` per session                    |
 
-**Output:** Sessions sorted by timestamp (newest first). When `--include-subagents` is set, each session includes a `subagent_count` field; otherwise the field is omitted entirely. Fields may be `null` for sessions with missing metadata. When `--last` is used, `_meta.total` reflects the pre-limit count and `_meta.hasMore` is `true` if results were truncated. With `--all-projects`, rows include `project`, `project_path_guess`, and `project_role`, and `_meta.included_projects` records the selected Claude project contexts.
+**Output:** Sessions sorted by timestamp (newest first). When `--include-subagents` is set, each session includes a `subagent_count` field; otherwise the field is omitted entirely. Fields may be `null` for sessions with missing metadata. When `--last` is used, `_meta.total` reflects the pre-limit count and `_meta.hasMore` is `true` if results were truncated. When multiple project contexts are included, rows include `project`, `project_path_guess`, `project_role`, and `session_ref`; `_meta.included_projects` records the selected Claude project contexts. `project_path_guess` is display-only; use raw `project` or `session_ref.project` with `--claude-project` for follow-up commands.
 
 ```json
 {
@@ -92,6 +95,27 @@ cc-session-tool list [--project <path>] [--all-projects] [--project-glob <patter
   "_meta": { "total": 1, "returned": 1, "hasMore": false }
 }
 ```
+
+---
+
+### `projects`
+
+Summarize Claude project transcript directories and expose stable raw project handles.
+
+```bash
+cc-session-tool projects [--glob <pattern>] [--project <path>]
+```
+
+Without `--project`, `projects` scans all top-level Claude project directories under `~/.claude/projects`. With `--project`, it returns the main project plus associated Claude worktree transcript directories. Rows are sorted by raw `project` basename.
+
+| Field | Description |
+| ----- | ----------- |
+| `project` | Raw Claude project directory basename; pass this to session commands as `--claude-project`. |
+| `project_path_guess` | Best-effort display path only. Do not use it as a stable handle. |
+| `project_role` | `main`, `worktree`, or `global`. |
+| `session_count` | Count of parent `.jsonl` sessions in that Claude project directory. |
+| `total_lines` | Total non-empty transcript lines across counted sessions. |
+| `first_session_at` / `last_session_at` | Earliest/latest metadata timestamp, or `null`. |
 
 ---
 
@@ -155,13 +179,27 @@ cc-session-tool shape <session> [--project <path> | --claude-project <project>]
 
 ---
 
+### `summary <session>`
+
+One-call triage summary for a session.
+
+```bash
+cc-session-tool summary <session> [--project <path> | --claude-project <project>]
+```
+
+The result combines the common first-pass fields agents previously gathered from `shape`, `tools`, `files`, and `messages`: model, timing, first prompt snippet, last assistant text snippet, tool counts, file access counts, and subagent metadata. When following a `search` or `list` row, use `session_ref.project` as `--claude-project`; do not use `project_path_guess` as a handle.
+
+---
+
 ### `tools <session>`
 
 Tool call log with condensed input summaries and outcome detection.
 
 ```bash
-cc-session-tool tools <session> [--project <path> | --claude-project <project>] [--name <tool>] [--failed] [--turn <N|N-M>]
+cc-session-tool tools <session> [--project <path> | --claude-project <project>] [--name <tool>|--name-match <text>] [--input-match <text>|--input-regex <regex>] [--failed] [--turn <N|N-M>]
 ```
+
+`--input-match` and `--input-regex` search the raw structured tool input, including values omitted or truncated in `input_summary`. `--name` and `--name-match` are mutually exclusive, as are the two input filters.
 
 **Output:**
 
@@ -426,7 +464,7 @@ cc-session-tool slice <session> --turn <N|N-M> [--project <path> | --claude-proj
 Find sessions matching structured filters. By default, search is scoped to the logical project derived from `--project <path>` or the current working directory, and it also includes associated Claude-managed worktree transcript directories. This agent-first default means a query from the main checkout can find work performed from a Claude worktree without `--all-projects`.
 
 ```bash
-cc-session-tool search [--project <path>] [--all-projects] [--project-glob <pattern>] [--tool <name>] [--input-match <text>] [--file <path>] [--text <text>] [--bash <text>] [--operation <op>] [--origin] [--sort <mode>] [--aggregate count-per-session] [--branch <name>] [--after <date>] [--before <date>] [--since <duration>] [--last <n>]
+cc-session-tool search [--project <path>] [--all-projects] [--project-glob <pattern>] [--tool <name>] [--input-match <text>|--input-regex <regex>] [--file <path>] [--text <text>|--text-regex <regex>] [--intent-match <text>|--intent-regex <regex>] [--bash <text>|--bash-regex <regex>] [--no-subagents] [--operation <op>] [--origin] [--sort <mode>] [--aggregate count-per-session|counters] [--counter NAME=text] [--counter-regex NAME=regex] [--bucket day|week] [--per-subagent] [--branch <name>] [--after <date>] [--before <date>] [--since <duration>] [--last <n>]
 ```
 
 | Option           | Default | Description |
@@ -436,20 +474,29 @@ cc-session-tool search [--project <path>] [--all-projects] [--project-glob <patt
 | `--project-glob` | —       | With `--all-projects`, filter by raw Claude project basename or display-only `project_path_guess`. Supports `*` and `?`. |
 | `--tool`         | —       | Match tool names by case-insensitive substring. |
 | `--input-match`  | —       | Match raw structured tool input by case-insensitive substring, including fields omitted or truncated by `input_summary`. |
+| `--input-regex`  | —       | Match raw structured tool input by regex. Mutually exclusive with `--input-match`. |
 | `--file`         | —       | Match touched file paths by substring. |
 | `--operation`    | all     | With `--file`, filter by matching file operation: `read`, `edit`, `write`, `grep`, `glob`. |
 | `--origin`       | false   | With `--file`, return earliest matching transcript write evidence. Implies `--operation write` and defaults to one result. |
 | `--sort`         | `session-newest` | Sort matches by `session-newest`, `match-earliest`, `match-newest`, or `project`. |
-| `--aggregate`    | `none`  | `count-per-session` returns per-session tool-input counts. Requires `--tool` or `--input-match`. |
-| `--text`         | —       | Match assistant text and thinking by case-insensitive substring. |
+| `--aggregate`    | `none`  | `count-per-session` returns per-session tool-input counts; `counters` returns named raw-input counters. |
+| `--counter` / `--counter-regex` | — | Named raw-input counter as `NAME=pattern`; requires `--aggregate counters`. |
+| `--bucket`       | `none`  | With `--aggregate counters`, bucket by `day` or `week`. Missing timestamps use `unknown`. |
+| `--per-subagent` | false   | With counter aggregation, emit transcript-level rows instead of parent session rollups. |
+| `--text`         | —       | Match user/assistant text and thinking by case-insensitive substring. |
+| `--text-regex`   | —       | Match user/assistant text and thinking by regex. |
+| `--intent-match` | —       | Match session intent sources (`slug`, first prompt token, first user message) by substring. |
+| `--intent-regex` | —       | Match session intent sources by regex. |
 | `--bash`         | —       | Match Bash command inputs by case-insensitive substring. |
+| `--bash-regex`   | —       | Match Bash command inputs by regex. |
+| `--no-subagents` | false   | Disable default one-level subagent transcript inclusion. |
 | `--branch`       | all     | Filter by git branch name. |
 | `--after`        | —       | Sessions after ISO 8601 date (mutually exclusive with `--since`). |
 | `--before`       | —       | Sessions before ISO 8601 date. |
 | `--since`        | —       | Sessions from the last duration: `30m`, `2h`, `1d`, `1w` (mutually exclusive with `--after`). |
 | `--last`         | all     | Return only the N matches after sorting. With `--origin`, defaults to 1 unless set. |
 
-At least one of `--tool`, `--input-match`, `--file`, `--text`, or `--bash` is required. You may provide more than one; multiple filters use AND semantics. `--operation` is valid only with `--file`, and it is tied to the same matching file access, not any other file access in the session.
+At least one selector is required: `--tool`, raw-input, file, text, intent, bash, or counter filter. You may provide more than one; multiple filters use AND semantics. `--operation` is valid only with `--file`, and it is tied to the same matching file access, not any other file access in the session.
 
 For absolute `--file` queries inside the logical project, search compares exact canonical path candidates first, then exact project-relative logical identity. For example, `/workspace/app/src/auth.ts` in the main checkout matches `/workspace/app/.claude/worktrees/feature-a/src/auth.ts` from a related Claude worktree as the same logical file `src/auth.ts`. If a worktree path reaches the same file through a symlinked directory, the realpath candidate can also match even when the lexical absolute paths differ. If both sides normalize to logical paths and they differ, search does not fall back to substring matching.
 
@@ -490,12 +537,14 @@ cc-session-tool search --tool Bash --input-match "bun test" --aggregate count-pe
         "tools": ["Read", "Edit"],
         "files": ["/workspace/app/src/auth.ts"],
         "normalized_files": ["src/auth.ts"],
-        "file_evidence": [
+        "evidence": [
           {
+            "kind": "file",
             "rawPath": "/workspace/app/.claude/worktrees/feature-a/src/auth.ts",
             "logicalPath": "src/auth.ts",
             "operation": "edit",
             "turn": 8,
+            "block_index": 0,
             "timestamp": "2026-03-07T22:34:10.000Z"
           }
         ],

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ cc-session-tool list [--project <path>] [--main-only] [--all-projects] [--projec
       "branch": "feature/auth",
       "timestamp": "2026-03-07T22:31:26.359Z",
       "version": "2.1.71",
+      "model": "claude-sonnet-4-5",
       "lines": 342,
       "slug": "snuggly-floating-barto"
     }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ bun run build
 
 ### Session Identifiers
 
-All commands except `list` require a `<session>` argument. Three forms are accepted:
+Session-scoped commands require a `<session>` argument; `list` and `projects` do not. Three forms are accepted:
 
 | Form        | Example                                | Resolution                                             |
 | ----------- | -------------------------------------- | ------------------------------------------------------ |

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,5 @@
+[test]
+# index.ts is validated by spawned CLI integration tests. Bun's coverage runner
+# does not attribute child-process execution back to the parent test process, so
+# coverage gating focuses on the modules exercised in-process.
+coveragePathIgnorePatterns = ["index.ts"]

--- a/index.test.ts
+++ b/index.test.ts
@@ -1369,10 +1369,12 @@ const FIXTURE_HOME = join(FIXTURE_DIR, 'home');
 const FIXTURE_CLAUDE_PROJECTS_ROOT = claudeProjectsRoot(FIXTURE_HOME);
 const FAKE_PROJECT = join(FIXTURE_DIR, 'fake-project');
 const SECOND_FAKE_PROJECT = join(FIXTURE_DIR, 'fake-project-worktree');
+const SUMMARY_PROJECT = join(FIXTURE_DIR, 'summary-project');
 const RELATED_PROJECT = join(tmpdir(), `ccsessionrelated${randomUUID().replace(/-/g, '')}`);
 const RELATED_WORKTREE_ROOT = join(RELATED_PROJECT, '.claude', 'worktrees', 'feature');
 const fakeDirName = mangleProjectPath(FAKE_PROJECT);
 const secondFakeDirName = mangleProjectPath(SECOND_FAKE_PROJECT);
+const summaryDirName = mangleProjectPath(SUMMARY_PROJECT);
 const relatedDirName = mangleProjectPath(RELATED_PROJECT);
 const relatedWorktreeDirName = mangleProjectPath(RELATED_WORKTREE_ROOT);
 const relatedDoubleDashWorktreeDirName = `${mangleProjectPath(RELATED_PROJECT)}--claude-worktrees-feature`;
@@ -1383,6 +1385,10 @@ const CLAUDE_DIR = join(
 const SECOND_CLAUDE_DIR = join(
   FIXTURE_CLAUDE_PROJECTS_ROOT,
   secondFakeDirName,
+);
+const SUMMARY_CLAUDE_DIR = join(
+  FIXTURE_CLAUDE_PROJECTS_ROOT,
+  summaryDirName,
 );
 const RELATED_CLAUDE_DIR = join(
   FIXTURE_CLAUDE_PROJECTS_ROOT,
@@ -1409,6 +1415,7 @@ const SESSION_ID_9 = 'ffffffcc-1111-2222-3333-444444444444';
 const SESSION_ID_10 = 'ffffffdd-1111-2222-3333-444444444444';
 const SESSION_ID_11 = 'ffffff11-1111-2222-3333-444444444444';
 const SESSION_ID_12 = 'ffffff22-1111-2222-3333-444444444444';
+const SESSION_ID_13 = 'ffffff33-1111-2222-3333-444444444444';
 const CROSS_PROJECT_FILE = 'cross-project-fixture-target.ts';
 const RELATED_PROJECT_FILE = 'related-origin-warning.ts';
 const RELATED_MISSING_CWD_FILE = 'related-missing-cwd.ts';
@@ -1507,14 +1514,40 @@ const SUBAGENT_ID = 'a8361bc';
 beforeAll(() => {
   mkdirSync(FAKE_PROJECT, { recursive: true });
   mkdirSync(SECOND_FAKE_PROJECT, { recursive: true });
+  mkdirSync(SUMMARY_PROJECT, { recursive: true });
   mkdirSync(RELATED_PROJECT, { recursive: true });
   mkdirSync(CLAUDE_DIR, { recursive: true });
   mkdirSync(SECOND_CLAUDE_DIR, { recursive: true });
+  mkdirSync(SUMMARY_CLAUDE_DIR, { recursive: true });
   mkdirSync(RELATED_CLAUDE_DIR, { recursive: true });
   mkdirSync(RELATED_WORKTREE_CLAUDE_DIR, { recursive: true });
   mkdirSync(RELATED_DOUBLE_DASH_WORKTREE_CLAUDE_DIR, { recursive: true });
   const lines = makeFixtureLines();
   writeFileSync(join(CLAUDE_DIR, `${SESSION_ID}.jsonl`), lines.join('\n') + '\n');
+  const fullTimingSummaryLines = [
+    JSON.stringify({
+      type: 'system',
+      sessionId: SESSION_ID_13,
+      timestamp: '2026-03-01T09:59:00.000Z',
+      gitBranch: 'main',
+      version: '2.1.0',
+    }),
+    JSON.stringify({
+      type: 'user',
+      timestamp: '2026-03-01T10:00:00.000Z',
+      message: { role: 'user', content: 'Summarize full timing' },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-03-01T10:02:00.000Z',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'Full timing response' }] },
+    }),
+    JSON.stringify({
+      type: 'summary',
+      timestamp: '2026-03-01T10:03:00.000Z',
+    }),
+  ];
+  writeFileSync(join(SUMMARY_CLAUDE_DIR, `${SESSION_ID_13}.jsonl`), fullTimingSummaryLines.join('\n') + '\n');
 
   // Subagent fixture: create subagents dir within the parent session UUID dir
   const subagentDir = join(CLAUDE_DIR, SESSION_ID, 'subagents');
@@ -1918,6 +1951,7 @@ afterAll(() => {
   rmSync(RELATED_PROJECT, { recursive: true, force: true });
   rmSync(CLAUDE_DIR, { recursive: true, force: true });
   rmSync(SECOND_CLAUDE_DIR, { recursive: true, force: true });
+  rmSync(SUMMARY_CLAUDE_DIR, { recursive: true, force: true });
   rmSync(RELATED_CLAUDE_DIR, { recursive: true, force: true });
   rmSync(RELATED_WORKTREE_CLAUDE_DIR, { recursive: true, force: true });
   rmSync(RELATED_DOUBLE_DASH_WORKTREE_CLAUDE_DIR, { recursive: true, force: true });
@@ -2375,6 +2409,23 @@ describe('summary integration', () => {
     expect(result.data.first_user_prompt).toEqual({ turn: 1, snippet: 'Subagent task' });
     expect(result.data.last_assistant_text).toEqual({ turn: 2, snippet: 'Subagent response' });
     expect(result.data.subagents).toEqual([]);
+  });
+
+  test('uses full transcript entries for timing while counting user and assistant turns', async () => {
+    const { exitCode, stdout } = await runCli(['summary', SESSION_ID_13, '--project', SUMMARY_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data).toMatchObject({
+      session_id: SESSION_ID_13,
+      started_at: '2026-03-01T09:59:00.000Z',
+      ended_at: '2026-03-01T10:03:00.000Z',
+      duration_ms: 240000,
+      turn_count: 2,
+      lines: 4,
+      first_user_prompt: { turn: 1, snippet: 'Summarize full timing' },
+      last_assistant_text: { turn: 2, snippet: 'Full timing response' },
+    });
   });
 });
 
@@ -4514,6 +4565,15 @@ describe('--claude-project session follow-up integration', () => {
     expect(result.ok).toBe(false);
     expect(result.error.code).toBe('INVALID_ARGS');
     expect(result.error.message).toContain('--claude-project');
+  });
+
+  test('valid missing --claude-project basename returns NOT_FOUND even when it contains flag text', async () => {
+    const { exitCode, stdout } = await runCli(['shape', SESSION_ID_8, '--claude-project=--claude-project']);
+    expect(exitCode).toBe(3);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe('NOT_FOUND');
+    expect(result.error.message).toContain('Claude project directory not found');
   });
 
   const conflictingCommandArgs = [

--- a/index.test.ts
+++ b/index.test.ts
@@ -2054,6 +2054,7 @@ describe('list integration', () => {
     const session1 = result.data.find((s: any) => s.session_id === SESSION_ID);
     expect(session1).toBeDefined();
     expect(session1.branch).toBe('main');
+    expect(session1.model).toBe('claude-sonnet-4-5');
     expect(session1.slug).toBe('test-slug-fixture');
   });
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
 import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { basename, join } from 'path';
 import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
 import {
   ERROR_CODES, success, failure, CliError, isCliError,
   parseTurnRange, truncateContent, inputSummary, determineOutcome, parseIntArg,
@@ -19,9 +20,16 @@ import {
 } from './index.ts';
 import {
   applyTruncationPolicy,
+  buildSessionSummary,
   contentBlocksForEntry,
+  countNonEmptyLines,
+  extractSessionIntent,
   extractSessionMetadata as extractTranscriptSessionMetadata,
+  parseSessionLines as parseTranscriptSessionLines,
+  parseSessionText as parseTranscriptSessionText,
   normalizedBlocks,
+  resolveByIdOrSlug as resolveTranscriptByIdOrSlug,
+  resolveSessionFile as resolveTranscriptSessionFile,
   resolveSessionWithText,
 } from './src/transcript.ts';
 import {
@@ -43,6 +51,10 @@ import {
   type SearchMeta,
 } from './src/search.ts';
 
+function uniqueTempName(prefix: string): string {
+  return `${prefix}-${randomUUID()}`;
+}
+
 // ============================================================================
 // Search Module Primitives
 // ============================================================================
@@ -55,16 +67,17 @@ describe('search matcher primitives', () => {
     expect(testTextMatcher(null, 'anything')).toBe(true);
   });
 
-  test('regex matcher is case-insensitive and rejects invalid patterns', () => {
+  test('regex matcher is case-sensitive and rejects invalid patterns', () => {
     const matcher = parseRegexMatcher('foo\\s+bar', '--text-regex');
-    expect(testTextMatcher(matcher, 'FOO   bar')).toBe(true);
+    expect(testTextMatcher(matcher, 'foo   bar')).toBe(true);
+    expect(testTextMatcher(matcher, 'FOO   bar')).toBe(false);
     expect(() => parseRegexMatcher('[', '--text-regex')).toThrow('Invalid --text-regex regex');
   });
 
   test('snippetForMatch centers around substring and regex matches', () => {
     const value = '0123456789abcdefghijKLMNOPQRSTuvwxyz';
     expect(snippetForMatch(value, parseSubstringMatcher('KLM')!, 10)).toContain('KLM');
-    expect(snippetForMatch(value, parseRegexMatcher('mnop', '--sample')!, 12)).toBe('ijKLMNOPQRST');
+    expect(snippetForMatch(value, parseRegexMatcher('MNOP', '--sample')!, 12)).toBe('ijKLMNOPQRST');
   });
 
   test('parseCounterArgs handles repeated substring and regex counters', () => {
@@ -556,7 +569,7 @@ describe('Claude project discovery helpers', () => {
   });
 
   test('listClaudeProjectRefs returns directories and skips files', () => {
-    const unique = `cc-session-tool-project-refs-${Date.now()}`;
+    const unique = uniqueTempName('cc-session-tool-project-refs');
     const root = join(tmpdir(), unique, '.claude', 'projects');
     const dirProject = `-${unique}-dir`;
     const worktreeProject = `-${unique}-worktree`;
@@ -668,7 +681,7 @@ describe('Claude project discovery helpers', () => {
   });
 
   test('buildScopedSearchScope returns main context only when worktrees are excluded', () => {
-    const unique = `cc-session-tool-scope-main-${Date.now()}`;
+    const unique = uniqueTempName('cc-session-tool-scope-main');
     const root = join(tmpdir(), unique, '.claude', 'projects');
     const projectPath = join(tmpdir(), unique, 'repo');
     const claudeDir = join(root, mangleProjectPath(projectPath));
@@ -697,7 +710,7 @@ describe('Claude project discovery helpers', () => {
   });
 
   test('buildScopedSearchScope includes both related hyphenated worktree refs without reverse-mangling', () => {
-    const unique = `cc-session-tool-scope-worktree-${Date.now()}`;
+    const unique = uniqueTempName('cc-session-tool-scope-worktree');
     const root = join(tmpdir(), unique, '.claude', 'projects');
     const projectPath = join(tmpdir(), unique, 'cc-session-tool', 'cc-session-tool');
     const mainProject = mangleProjectPath(projectPath);
@@ -725,7 +738,7 @@ describe('Claude project discovery helpers', () => {
   });
 
   test('buildScopedSearchScope tolerates a missing Claude projects root after main project resolves', () => {
-    const unique = `cc-session-tool-scope-missing-root-${Date.now()}`;
+    const unique = uniqueTempName('cc-session-tool-scope-missing-root');
     const root = join(tmpdir(), unique, '.claude', 'projects');
     const projectPath = join(tmpdir(), unique, 'repo');
     mkdirSync(join(root, mangleProjectPath(projectPath)), { recursive: true });
@@ -743,7 +756,7 @@ describe('Claude project discovery helpers', () => {
   });
 
   test('listSearchTargetsForContext includes context on targets', () => {
-    const unique = `cc-session-tool-target-context-${Date.now()}`;
+    const unique = uniqueTempName('cc-session-tool-target-context');
     const root = join(tmpdir(), unique, '.claude', 'projects');
     const projectPath = join(tmpdir(), unique, 'repo');
     const claudeDir = join(root, mangleProjectPath(projectPath));
@@ -773,7 +786,7 @@ describe('Claude project discovery helpers', () => {
       worktreeRoot: null,
       projectRef: {
         project: '-tmp-missing-project',
-        claude_dir: join(tmpdir(), `cc-session-tool-missing-${Date.now()}`),
+        claude_dir: join(tmpdir(), uniqueTempName('cc-session-tool-missing')),
         project_path_guess: '/tmp/missing/project',
       },
     };
@@ -795,7 +808,7 @@ describe('Claude project discovery helpers', () => {
   });
 
   test('selectProjectContexts filters all-project contexts and reports skipped projects', () => {
-    const unique = `cc-session-tool-selection-${Date.now()}`;
+    const unique = uniqueTempName('cc-session-tool-selection');
     const root = join(tmpdir(), unique, '.claude', 'projects');
     const projectA = '/tmp/project-alpha';
     const projectB = '/tmp/project-beta';
@@ -1078,7 +1091,7 @@ describe('Claude project discovery helpers', () => {
   });
 
   test('logical file matching uses realpath candidates for supplied project roots', () => {
-    const unique = `cc-session-tool-realpath-${Date.now()}`;
+    const unique = uniqueTempName('cc-session-tool-realpath');
     const root = join(tmpdir(), unique);
     const realProject = join(root, 'real-project');
     const linkedProject = join(root, 'linked-project');
@@ -1105,7 +1118,7 @@ describe('Claude project discovery helpers', () => {
   });
 
   test('canonical file matching equates symlinked main and worktree paths', () => {
-    const unique = `cc-session-tool-canonical-${Date.now()}`;
+    const unique = uniqueTempName('cc-session-tool-canonical');
     const root = join(tmpdir(), unique);
     const projectRoot = join(root, 'repo');
     const worktreeRoot = join(projectRoot, '.claude', 'worktrees', 'feature-a');
@@ -1303,7 +1316,7 @@ describe('resolveClaudeProjectDir', () => {
   });
 
   test('resolves against an explicit Claude projects root', () => {
-    const unique = `cc-session-tool-resolve-root-${Date.now()}`;
+    const unique = uniqueTempName('cc-session-tool-resolve-root');
     const root = join(tmpdir(), unique, '.claude', 'projects');
     const projectPath = join(tmpdir(), unique, 'project');
     const claudeDir = join(root, mangleProjectPath(projectPath));
@@ -1317,7 +1330,7 @@ describe('resolveClaudeProjectDir', () => {
   });
 
   test('resolves project paths with trailing slashes to the same Claude directory', () => {
-    const unique = `cc-session-tool-resolve-trailing-${Date.now()}`;
+    const unique = uniqueTempName('cc-session-tool-resolve-trailing');
     const root = join(tmpdir(), unique, '.claude', 'projects');
     const projectPath = join(tmpdir(), unique, 'project');
     const claudeDir = join(root, mangleProjectPath(projectPath));
@@ -1351,12 +1364,12 @@ describe('CLI', () => {
 // Integration Tests with Fixture Data
 // ============================================================================
 
-const FIXTURE_DIR = join(tmpdir(), `cc-session-test-${Date.now()}`);
+const FIXTURE_DIR = join(tmpdir(), uniqueTempName('cc-session-test'));
 const FIXTURE_HOME = join(FIXTURE_DIR, 'home');
 const FIXTURE_CLAUDE_PROJECTS_ROOT = claudeProjectsRoot(FIXTURE_HOME);
 const FAKE_PROJECT = join(FIXTURE_DIR, 'fake-project');
 const SECOND_FAKE_PROJECT = join(FIXTURE_DIR, 'fake-project-worktree');
-const RELATED_PROJECT = join(tmpdir(), `ccsessionrelated${Date.now()}`);
+const RELATED_PROJECT = join(tmpdir(), `ccsessionrelated${randomUUID().replace(/-/g, '')}`);
 const RELATED_WORKTREE_ROOT = join(RELATED_PROJECT, '.claude', 'worktrees', 'feature');
 const fakeDirName = mangleProjectPath(FAKE_PROJECT);
 const secondFakeDirName = mangleProjectPath(SECOND_FAKE_PROJECT);
@@ -1951,7 +1964,7 @@ function parseOutput(stdout: string) {
 
 describe('scanSearchTarget', () => {
   test('no-context file filters require a matching raw file access', async () => {
-    const unique = `cc-session-tool-no-context-search-${Date.now()}`;
+    const unique = uniqueTempName('cc-session-tool-no-context-search');
     const root = join(tmpdir(), unique);
     const sessionId = '11111111-2222-3333-4444-555555555555';
     const sessionFile = join(root, `${sessionId}.jsonl`);
@@ -2659,6 +2672,118 @@ describe('transcript module foundation', () => {
     expect(result.metadata.branch).toBe('main');
   });
 
+  test('transcript parser and line counter handle empty, malformed, and valid rows', async () => {
+    expect(parseTranscriptSessionText('')).toEqual([]);
+    expect(() => parseTranscriptSessionText('not json\n')).toThrow('Session file contains no valid entries');
+    expect(countNonEmptyLines('\n one \n\n two')).toBe(2);
+
+    const filePath = join(CLAUDE_DIR, 'transcript-module-parse.jsonl');
+    writeFileSync(filePath, [
+      '',
+      'not json',
+      JSON.stringify({ type: 'user', message: { content: 'valid row' } }),
+      JSON.stringify({ nope: true }),
+    ].join('\n'));
+
+    expect(await parseTranscriptSessionLines(filePath)).toEqual([
+      { type: 'user', message: { content: 'valid row' } },
+    ]);
+  });
+
+  test('transcript intent extraction includes slug, first prompt token, and first message', () => {
+    const intents = extractSessionIntent([
+      { type: 'assistant', message: { content: 'ignored assistant first' } },
+      { type: 'user', message: { content: '/plan install packages' } },
+    ], { slug: 'module-slug' });
+
+    expect(intents).toEqual([
+      { source: 'slug', value: 'module-slug' },
+      { source: 'first_prompt', value: '/plan' },
+      { source: 'first_message', value: '/plan install packages' },
+    ]);
+  });
+
+  test('transcript resolver handles prefix, slug, ambiguity, missing, and subagent targets', async () => {
+    expect(await resolveTranscriptByIdOrSlug(CLAUDE_DIR, SESSION_ID.slice(0, 8)))
+      .toBe(join(CLAUDE_DIR, `${SESSION_ID}.jsonl`));
+    expect(await resolveTranscriptByIdOrSlug(CLAUDE_DIR, 'late-slug-test'))
+      .toBe(join(CLAUDE_DIR, `${SESSION_ID_5}.jsonl`));
+
+    await expect(resolveTranscriptByIdOrSlug(CLAUDE_DIR, 'test-slug-fixture'))
+      .rejects.toThrow('Ambiguous slug');
+    await expect(resolveTranscriptByIdOrSlug(CLAUDE_DIR, 'no-such-session'))
+      .rejects.toThrow('No session found');
+    await expect(resolveTranscriptByIdOrSlug(CLAUDE_DIR, '../bad'))
+      .rejects.toThrow('Invalid session ID');
+
+    expect(await resolveTranscriptSessionFile(CLAUDE_DIR, `${SESSION_ID}:${SUBAGENT_ID}`)).toEqual({
+      filePath: join(CLAUDE_DIR, SESSION_ID, 'subagents', `agent-${SUBAGENT_ID}.jsonl`),
+      sessionId: SESSION_ID,
+      agentId: SUBAGENT_ID,
+    });
+    await expect(resolveTranscriptSessionFile(CLAUDE_DIR, `${SESSION_ID}:bad/id`))
+      .rejects.toThrow('Invalid agent ID');
+    await expect(resolveTranscriptSessionFile(CLAUDE_DIR, `${SESSION_ID}:missing`))
+      .rejects.toThrow('No subagent');
+  });
+
+  test('buildSessionSummary computes snippets, timing, tool counts, file counts, and subagents', () => {
+    const longPrompt = 'x'.repeat(450);
+    const summary = buildSessionSummary({
+      sessionId: SESSION_ID,
+      agentId: null,
+      lineCount: 4,
+      metadata: {
+        branch: 'main',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        version: '1.0.0',
+        slug: 'summary-slug',
+        model: 'claude-sonnet-4-5',
+      },
+      subagents: [{ agent_id: SUBAGENT_ID, agent_type: 'worker', description: 'does work', lines: 5, timestamp: '2026-01-01T00:00:04.000Z' }],
+      entries: [
+        { type: 'system', timestamp: '2026-01-01T00:00:00.000Z' },
+        { type: 'user', timestamp: '2026-01-01T00:00:01.000Z', message: { content: longPrompt } },
+        {
+          type: 'assistant',
+          timestamp: '2026-01-01T00:00:03.000Z',
+          message: {
+            content: [
+              { type: 'tool_use', name: 'Read', id: 'read_1', input: { file_path: 'a.ts' } },
+              { type: 'tool_use', name: 'Edit', id: 'edit_1', input: { file_path: 'a.ts' } },
+              { type: 'tool_use', name: 'Write', id: 'write_1', input: { file_path: 'b.ts' } },
+              { type: 'tool_use', name: 'Grep', id: 'grep_1', input: { path: 'src' } },
+              { type: 'tool_use', name: 'Glob', id: 'glob_1', input: { path: 'src' } },
+              { type: 'tool_use', name: 'Bash', id: 'bash_1', input: { command: 'bun test' } },
+              { type: 'text', text: 'done' },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      session_id: SESSION_ID,
+      agent_id: null,
+      branch: 'main',
+      model: 'claude-sonnet-4-5',
+      started_at: '2026-01-01T00:00:00.000Z',
+      ended_at: '2026-01-01T00:00:03.000Z',
+      duration_ms: 3000,
+      turn_count: 2,
+      lines: 4,
+      slug: 'summary-slug',
+      last_assistant_text: { turn: 2, snippet: 'done' },
+      tool_counts: { Read: 1, Edit: 1, Write: 1, Grep: 1, Glob: 1, Bash: 1 },
+      files_touched: { read: 1, edit: 1, write: 1, grep: 1, glob: 1 },
+      subagents: [{ agent_id: SUBAGENT_ID, agent_type: 'worker', description: 'does work', lines: 5, timestamp: '2026-01-01T00:00:04.000Z' }],
+    });
+    expect(summary.first_user_prompt).toEqual({
+      turn: 1,
+      snippet: `${'x'.repeat(400)}...[truncated, 450 chars]`,
+    });
+  });
+
   test('applyTruncationPolicy centralizes per-kind max character behavior', () => {
     expect(applyTruncationPolicy('hello world', { textMaxChars: 5 }, 'text'))
       .toBe('hello...[truncated, 11 chars]');
@@ -2671,7 +2796,7 @@ describe('transcript module foundation', () => {
 
 describe('project-selection module foundation', () => {
   test('module project scope helpers preserve existing target shape', () => {
-    const unique = `cc-session-tool-module-target-${Date.now()}`;
+    const unique = uniqueTempName('cc-session-tool-module-target');
     const root = join(tmpdir(), unique, '.claude', 'projects');
     const projectPath = join(tmpdir(), unique, 'repo');
     const claudeDir = join(root, mangleProjectPathModule(projectPath));

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
 import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { basename, join } from 'path';
 import { tmpdir } from 'os';
 import {
   ERROR_CODES, success, failure, CliError, isCliError,
@@ -17,6 +17,207 @@ import {
   extractWorktreeStatePaths, collectObservedWorktreeRoots, absolutePathCandidatesFor,
   scanSearchTarget,
 } from './index.ts';
+import {
+  applyTruncationPolicy,
+  contentBlocksForEntry,
+  extractSessionMetadata as extractTranscriptSessionMetadata,
+  normalizedBlocks,
+  resolveSessionWithText,
+} from './src/transcript.ts';
+import {
+  buildScopedSearchScope as buildScopedSearchScopeModule,
+  listSearchTargetsForContext as listSearchTargetsForContextModule,
+  mangleProjectPath as mangleProjectPathModule,
+} from './src/project-selection.ts';
+import {
+  aggregateCounterRows,
+  attachCounterTranscriptResults,
+  bucketCounterRows,
+  evidenceTimestamps,
+  parseCounterArgs,
+  parseRegexMatcher,
+  parseSubstringMatcher,
+  snippetForMatch,
+  testTextMatcher,
+  type SearchMatch,
+  type SearchMeta,
+} from './src/search.ts';
+
+// ============================================================================
+// Search Module Primitives
+// ============================================================================
+
+describe('search matcher primitives', () => {
+  test('substring matcher is case-insensitive and null matcher passes', () => {
+    const matcher = parseSubstringMatcher('Needle');
+    expect(testTextMatcher(matcher, 'haystack needle value')).toBe(true);
+    expect(testTextMatcher(matcher, 'haystack value')).toBe(false);
+    expect(testTextMatcher(null, 'anything')).toBe(true);
+  });
+
+  test('regex matcher is case-insensitive and rejects invalid patterns', () => {
+    const matcher = parseRegexMatcher('foo\\s+bar', '--text-regex');
+    expect(testTextMatcher(matcher, 'FOO   bar')).toBe(true);
+    expect(() => parseRegexMatcher('[', '--text-regex')).toThrow('Invalid --text-regex regex');
+  });
+
+  test('snippetForMatch centers around substring and regex matches', () => {
+    const value = '0123456789abcdefghijKLMNOPQRSTuvwxyz';
+    expect(snippetForMatch(value, parseSubstringMatcher('KLM')!, 10)).toContain('KLM');
+    expect(snippetForMatch(value, parseRegexMatcher('mnop', '--sample')!, 12)).toBe('ijKLMNOPQRST');
+  });
+
+  test('parseCounterArgs handles repeated substring and regex counters', () => {
+    const counters = parseCounterArgs(['reads=Read', 'writes=Write=file'], 'bash=\\brg\\b');
+    expect(counters.map(counter => ({
+      name: counter.name,
+      source: counter.source,
+      mode: counter.matcher.mode,
+      raw: counter.matcher.raw,
+    }))).toEqual([
+      { name: 'reads', source: 'substring', mode: 'substring', raw: 'Read' },
+      { name: 'writes', source: 'substring', mode: 'substring', raw: 'Write=file' },
+      { name: 'bash', source: 'regex', mode: 'regex', raw: '\\brg\\b' },
+    ]);
+  });
+
+  test('parseCounterArgs rejects malformed and reserved counter names', () => {
+    expect(() => parseCounterArgs('missingSeparator', undefined)).toThrow('expected NAME=PATTERN');
+    expect(() => parseCounterArgs('1bad=value', undefined)).toThrow('Invalid counter name');
+    expect(() => parseCounterArgs('constructor=value', undefined)).toThrow('reserved name');
+    expect(() => parseCounterArgs(undefined, 'rx=[')).toThrow('Invalid --counter-regex rx regex');
+  });
+
+  test('evidenceTimestamps filters by kind and sorts timestamps', () => {
+    const match: SearchMatch = {
+      session_id: 's1',
+      branch: null,
+      timestamp: '2026-03-01T00:00:00.000Z',
+      slug: null,
+      model: null,
+      session_ref: { session_id: 's1', project: '-tmp-project' },
+      matches: {
+        tools: [],
+        files: [],
+        turns: [1, 2],
+        evidence: [
+          { kind: 'tool_input', turn: 1, block_index: 0, timestamp: '2026-03-03T00:00:00.000Z', tool: 'Read' },
+          { kind: 'file', turn: 2, block_index: 0, timestamp: '2026-03-02T00:00:00.000Z', rawPath: 'a.ts', operation: 'read' },
+          { kind: 'file', turn: 3, block_index: 0, timestamp: null, rawPath: 'b.ts', operation: 'write' },
+        ],
+      },
+    };
+    expect(evidenceTimestamps(match)).toEqual([
+      '2026-03-02T00:00:00.000Z',
+      '2026-03-03T00:00:00.000Z',
+    ]);
+    expect(evidenceTimestamps(match, 'file')).toEqual(['2026-03-02T00:00:00.000Z']);
+  });
+
+  test('SearchMeta contains only active search metadata fields', () => {
+    const meta: SearchMeta = {
+      total: 0,
+      returned: 0,
+      hasMore: false,
+      projects_scanned: 1,
+      included_projects: [],
+      skipped_projects: [],
+    };
+    expect(meta).not.toHaveProperty('warning');
+    expect(meta).not.toHaveProperty('related_projects');
+    expect(meta).not.toHaveProperty('project');
+  });
+
+  test('counter aggregation uses complete raw tool calls, session_ref keys, and parent rollup', () => {
+    const match: SearchMatch = {
+      session_id: 'parent-session',
+      branch: 'main',
+      timestamp: '2026-03-05T12:00:00.000Z',
+      slug: '/plan-counter-test',
+      model: 'claude-sonnet-4-5',
+      project_path_guess: '/workspace/project',
+      project_role: 'worktree',
+      session_ref: { session_id: 'parent-session', project: '-workspace-project' },
+      matches: { tools: [], files: [], turns: [], evidence: [] },
+    };
+    attachCounterTranscriptResults(match, [
+      {
+        target: { filePath: '/tmp/parent.jsonl', sessionId: 'parent-session', parentSessionId: null, agentId: null },
+        metadata: { branch: 'main', timestamp: '2026-03-05T12:00:00.000Z', version: null, slug: '/plan-counter-test', model: 'claude-sonnet-4-5' },
+        allToolCalls: [
+          { turn: 1, block_index: 0, timestamp: '2026-03-05T12:01:00.000Z', tool: 'Bash', input_summary: 'rg', rawInput: { command: 'rg .claude-tracking' }, agentId: null, parentSessionId: null, isSubagent: false },
+        ],
+      },
+      {
+        target: { filePath: '/tmp/sub.jsonl', sessionId: 'parent-session', parentSessionId: 'parent-session', agentId: 'agent_a' },
+        metadata: { branch: 'main', timestamp: null, version: null, slug: null, model: null },
+        allToolCalls: [
+          { turn: 1, block_index: 0, timestamp: null, tool: 'Bash', input_summary: 'find', rawInput: { command: 'find .claude-tracking -name implementation.md' }, agentId: 'agent_a', parentSessionId: 'parent-session', isSubagent: true },
+          { turn: 2, block_index: 0, timestamp: null, tool: 'Read', input_summary: 'file', rawInput: { file_path: '.claude-tracking/011/progress.json' }, agentId: 'agent_a', parentSessionId: 'parent-session', isSubagent: true },
+        ],
+      },
+    ]);
+
+    const counters = parseCounterArgs('tracking=.claude-tracking', 'find_cmd=^\\{\"command\":\"find');
+    const rows = aggregateCounterRows([match], counters, { explicitSelector: false, perSubagent: false, tool: 'Bash' });
+    expect(rows).toEqual([
+      expect.objectContaining({
+        session_id: 'parent-session',
+        project: '-workspace-project',
+        project_path_guess: '/workspace/project',
+        project_role: 'worktree',
+        session_ref: { session_id: 'parent-session', project: '-workspace-project' },
+        counts: { tracking: 2, find_cmd: 1 },
+        total_matches: 3,
+      }),
+    ]);
+  });
+
+  test('counter aggregation supports zero-count selectors, per-subagent rows, and buckets', () => {
+    const match: SearchMatch = {
+      session_id: 'bucket-session',
+      branch: 'main',
+      timestamp: '2026-03-08T12:00:00.000Z',
+      slug: null,
+      model: null,
+      session_ref: { session_id: 'bucket-session', project: '-workspace-bucket' },
+      matches: { tools: [], files: [], turns: [], evidence: [] },
+    };
+    attachCounterTranscriptResults(match, [
+      {
+        target: { filePath: '/tmp/parent.jsonl', sessionId: 'bucket-session', parentSessionId: null, agentId: null },
+        metadata: { branch: 'main', timestamp: '2026-03-08T12:00:00.000Z', version: null, slug: null, model: null },
+        allToolCalls: [],
+      },
+      {
+        target: { filePath: '/tmp/sub.jsonl', sessionId: 'bucket-session', parentSessionId: 'bucket-session', agentId: 'agent_b' },
+        metadata: { branch: 'main', timestamp: null, version: null, slug: null, model: null },
+        allToolCalls: [
+          { turn: 1, block_index: 0, timestamp: null, tool: 'Bash', input_summary: 'rg', rawInput: { command: 'rg bucket-marker' }, agentId: 'agent_b', parentSessionId: 'bucket-session', isSubagent: true },
+        ],
+      },
+    ]);
+
+    const counters = parseCounterArgs('marker=bucket-marker', undefined);
+    expect(aggregateCounterRows([match], counters, { explicitSelector: false, perSubagent: true }).map(row => row.agent_id)).toEqual(['agent_b']);
+
+    const rows = aggregateCounterRows([match], counters, { explicitSelector: true, perSubagent: true });
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ counts: { marker: 0 }, total_matches: 0 });
+    expect(rows[1]).toMatchObject({
+      agent_id: 'agent_b',
+      parent_session_id: 'bucket-session',
+      is_subagent: true,
+      session_ref: { session_id: 'bucket-session', project: '-workspace-bucket', agent_id: 'agent_b' },
+      counts: { marker: 1 },
+    });
+    expect(bucketCounterRows(rows, 'day')).toEqual([
+      { bucket: '2026-03-08', sessions: 1, counts: { marker: 0 }, total_matches: 0 },
+      { bucket: 'unknown', sessions: 1, counts: { marker: 1 }, total_matches: 1 },
+    ]);
+    expect(bucketCounterRows(rows, 'week')[0]!.bucket).toBe('2026-03-02');
+  });
+});
 
 // ============================================================================
 // Response Helpers
@@ -1233,6 +1434,7 @@ function makeFixtureLines(): string[] {
       slug: 'parent-subagent-test',
       message: {
         role: 'assistant',
+        model: 'claude-sonnet-4-5',
         content: [
           { type: 'thinking', thinking: 'Let me think about this carefully and determine the best approach for the user.' },
           { type: 'tool_use', name: 'Grep', id: 'tool_1', input: { pattern: 'hello', path: 'src/' } },
@@ -1382,7 +1584,7 @@ beforeAll(() => {
       gitBranch: 'feature',
       version: '2.1.0',
       slug: 'test-slug-fixture',
-      message: { role: 'user', content: 'Second session' },
+      message: { role: 'user', content: [{ type: 'text', text: 'User array content marker for text search.' }] },
     }),
     JSON.stringify({
       type: 'assistant',
@@ -1403,14 +1605,14 @@ beforeAll(() => {
     JSON.stringify({
       type: 'user', sessionId: SESSION_ID_3, timestamp: '2026-03-03T10:00:00.000Z',
       gitBranch: 'main', version: '2.1.0', slug: 'multi-block-test',
-      message: { role: 'user', content: 'Test multi-block' },
+      message: { role: 'user', content: 'Test multi-block /plan intent' },
     }),
     JSON.stringify({
       type: 'assistant', timestamp: '2026-03-03T10:01:00.000Z',
       message: {
         role: 'assistant',
         content: [
-          { type: 'thinking', thinking: 'Considering the approach...' },
+          { type: 'thinking', thinking: `Considering the approach... ${'x'.repeat(260)}` },
           { type: 'text', text: 'Here is my answer.' },
         ],
         usage: { input_tokens: 50, output_tokens: 25 },
@@ -1423,7 +1625,7 @@ beforeAll(() => {
     JSON.stringify({
       type: 'user', sessionId: SESSION_ID_4, timestamp: '2026-03-04T10:00:00.000Z',
       gitBranch: 'main', version: '2.1.0', slug: 'bash-test-session',
-      message: { role: 'user', content: 'Install express' },
+      message: { role: 'user', content: '/plan Install express' },
     }),
     JSON.stringify({
       type: 'assistant', timestamp: '2026-03-04T10:01:00.000Z',
@@ -1449,6 +1651,30 @@ beforeAll(() => {
     }),
   ];
   writeFileSync(join(CLAUDE_DIR, `${SESSION_ID_4}.jsonl`), lines4.join('\n') + '\n');
+  const counterSubagentDir = join(CLAUDE_DIR, SESSION_ID_4, 'subagents');
+  mkdirSync(counterSubagentDir, { recursive: true });
+  const counterSubagentLines = [
+    JSON.stringify({
+      type: 'user',
+      sessionId: SESSION_ID_4,
+      timestamp: '2026-03-04T10:03:00.000Z',
+      gitBranch: 'main',
+      version: '2.1.0',
+      message: { role: 'user', content: 'Count tracking usage' },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-03-04T10:04:00.000Z',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', name: 'Bash', id: 'tool_counter_bash_1', input: { command: 'rg .claude-tracking implementation.md' } },
+        ],
+        usage: { input_tokens: 30, output_tokens: 10 },
+      },
+    }),
+  ];
+  writeFileSync(join(counterSubagentDir, `agent-counter_agent.jsonl`), counterSubagentLines.join('\n') + '\n');
 
   const lateSlugLines = [
     LATE_SLUG_FIRST_LINE,
@@ -1692,9 +1918,28 @@ function runCli(args: string[]): Promise<{ exitCode: number; stdout: string; std
       stdout: 'pipe',
       stderr: 'pipe',
     });
+    const stdoutPromise = new Response(proc.stdout).text();
+    const stderrPromise = new Response(proc.stderr).text();
     const exitCode = await proc.exited;
-    const stdout = await new Response(proc.stdout).text();
-    const stderr = await new Response(proc.stderr).text();
+    const stdout = await stdoutPromise;
+    const stderr = await stderrPromise;
+    resolve({ exitCode, stdout, stderr });
+  });
+}
+
+function runCliHelp(args: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise(async (resolve) => {
+    const proc = Bun.spawn(['bun', 'run', 'index.ts', ...args], {
+      cwd: import.meta.dir,
+      env: { ...process.env, HOME: FIXTURE_HOME, NODE_ENV: 'development' },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const stdoutPromise = new Response(proc.stdout).text();
+    const stderrPromise = new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    const stdout = await stdoutPromise;
+    const stderr = await stderrPromise;
     resolve({ exitCode, stdout, stderr });
   });
 }
@@ -1836,6 +2081,66 @@ describe('list integration', () => {
     expect(result.error.message).toContain('mutually exclusive');
   });
 
+  test('scoped list includes associated worktree projects by default and exposes session_ref handles', async () => {
+    const { exitCode, stdout } = await runCli(['list', '--project', RELATED_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result._meta.projects_scanned).toBe(3);
+    expect(result._meta.included_projects).toEqual([
+      {
+        project: relatedDirName,
+        project_path_guess: RELATED_PROJECT,
+        project_role: 'main',
+      },
+      {
+        project: relatedDoubleDashWorktreeDirName,
+        project_path_guess: projectPathGuessFromClaudeProject(relatedDoubleDashWorktreeDirName),
+        project_role: 'worktree',
+      },
+      {
+        project: relatedWorktreeDirName,
+        project_path_guess: projectPathGuessFromClaudeProject(relatedWorktreeDirName),
+        project_role: 'worktree',
+      },
+    ]);
+    const worktreeSession = result.data.find((s: any) => s.session_id === SESSION_ID_8);
+    expect(worktreeSession).toMatchObject({
+      project: relatedWorktreeDirName,
+      project_role: 'worktree',
+      session_ref: { session_id: SESSION_ID_8, project: relatedWorktreeDirName },
+    });
+  });
+
+  test('list --main-only skips associated worktree projects', async () => {
+    const { exitCode, stdout } = await runCli(['list', '--project', RELATED_PROJECT, '--main-only']);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.map((s: any) => s.session_id)).toEqual([SESSION_ID_7]);
+    expect(result._meta).not.toHaveProperty('included_projects');
+  });
+
+  test('list intent filters inspect slug and first user message', async () => {
+    const slugMatch = parseOutput((await runCli(['list', '--project', FAKE_PROJECT, '--intent-match', 'bash-test-session'])).stdout);
+    expect(slugMatch.data.map((s: any) => s.session_id)).toEqual([SESSION_ID_4]);
+
+    const regexMatch = parseOutput((await runCli(['list', '--project', FAKE_PROJECT, '--intent-regex', '/plan\\s+Install'])).stdout);
+    expect(regexMatch.data.map((s: any) => s.session_id)).toEqual([SESSION_ID_4]);
+  });
+
+  test('list rejects documentation-sensitive flag conflicts', async () => {
+    const mainOnlyAllProjects = parseOutput((await runCli(['list', '--all-projects', '--main-only'])).stdout);
+    expect(mainOnlyAllProjects.ok).toBe(false);
+    expect(mainOnlyAllProjects.error.code).toBe('INVALID_ARGS');
+    expect(mainOnlyAllProjects.error.message).toContain('--main-only cannot be used with --all-projects');
+
+    const intentConflict = parseOutput((await runCli(['list', '--project', FAKE_PROJECT, '--intent-match', 'x', '--intent-regex', 'x'])).stdout);
+    expect(intentConflict.ok).toBe(false);
+    expect(intentConflict.error.code).toBe('INVALID_ARGS');
+    expect(intentConflict.error.message).toContain('--intent-match and --intent-regex are mutually exclusive');
+  });
+
   test('--all-projects lists sessions with project metadata', async () => {
     const { exitCode, stdout } = await runCli(['list', '--all-projects']);
     expect(exitCode).toBe(0);
@@ -1880,6 +2185,90 @@ describe('list integration', () => {
     expect(result.ok).toBe(false);
     expect(result.error.code).toBe('INVALID_ARGS');
     expect(result.error.message).toContain('--project-glob requires --all-projects');
+  });
+});
+
+describe('projects integration', () => {
+  test('projects --glob returns deterministic raw project summaries', async () => {
+    const { exitCode, stdout } = await runCli(['projects', '--glob', '*fake-project*']);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.map((p: any) => p.project)).toEqual([fakeDirName, secondFakeDirName]);
+    expect(result.data[0]).toMatchObject({
+      project: fakeDirName,
+      project_path_guess: projectPathGuessFromClaudeProject(fakeDirName),
+      project_role: 'global',
+      session_count: 5,
+    });
+    expect(result.data[1]).toMatchObject({
+      project: secondFakeDirName,
+      project_path_guess: projectPathGuessFromClaudeProject(secondFakeDirName),
+      project_role: 'global',
+      session_count: 1,
+    });
+  });
+
+  test('projects --project summarizes main and associated worktree handles', async () => {
+    const { exitCode, stdout } = await runCli(['projects', '--project', RELATED_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.map((p: any) => p.project)).toEqual([
+      relatedDirName,
+      relatedDoubleDashWorktreeDirName,
+      relatedWorktreeDirName,
+    ]);
+    expect(result.data.find((p: any) => p.project === relatedDirName)).toMatchObject({
+      project_path_guess: RELATED_PROJECT,
+      project_role: 'main',
+      session_count: 1,
+      first_session_at: '2026-03-07T10:00:00.000Z',
+      last_session_at: '2026-03-07T10:00:00.000Z',
+    });
+    expect(result.data.find((p: any) => p.project === relatedWorktreeDirName)).toMatchObject({
+      project_role: 'worktree',
+      session_count: 5,
+    });
+  });
+});
+
+describe('help contract integration', () => {
+  test('top-level help exposes projects and stable handle contract', async () => {
+    const { exitCode, stdout, stderr } = await runCliHelp(['--help']);
+    const help = stdout + stderr;
+    expect(exitCode).toBe(0);
+    expect(help).toContain('stable raw project/session_ref handles');
+    expect(help).toContain('projects');
+  });
+
+  test('command help includes agent-facing contract phrases', async () => {
+    const listProcess = await runCliHelp(['list', '--help']);
+    const listHelp = listProcess.stdout + listProcess.stderr;
+    expect(listHelp).toContain('associated Claude worktrees by default');
+    expect(listHelp).toContain('--main-only');
+    expect(listHelp).toContain('raw Claude project basename');
+
+    const searchProcess = await runCliHelp(['search', '--help']);
+    const searchHelp = searchProcess.stdout + searchProcess.stderr;
+    expect(searchHelp).toContain('unified evidence');
+    expect(searchHelp).toContain('worktrees and subagents by default');
+    expect(searchHelp).toContain('same matching file access');
+
+    const toolsProcess = await runCliHelp(['tools', '--help']);
+    const toolsHelp = toolsProcess.stdout + toolsProcess.stderr;
+    expect(toolsHelp).toContain('raw structured inputs');
+    expect(toolsHelp).toContain('input_summary');
+
+    const projectsProcess = await runCliHelp(['projects', '--help']);
+    const projectsHelp = projectsProcess.stdout + projectsProcess.stderr;
+    expect(projectsHelp).toContain('raw project handles');
+    expect(projectsHelp).toContain('project_path_guess');
+
+    const summaryProcess = await runCliHelp(['summary', '--help']);
+    const summaryHelp = summaryProcess.stdout + summaryProcess.stderr;
+    expect(summaryHelp).toContain('session_ref.project');
+    expect(summaryHelp).toContain('--claude-project');
   });
 });
 
@@ -1935,6 +2324,47 @@ describe('shape integration', () => {
   });
 });
 
+describe('summary integration', () => {
+  test('returns one-call triage fields for a parent session without rolling up subagent activity', async () => {
+    const { exitCode, stdout } = await runCli(['summary', SESSION_ID, '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result._meta).toEqual({ total: 1, returned: 1, hasMore: false });
+    expect(result.data).toMatchObject({
+      session_id: SESSION_ID,
+      agent_id: null,
+      branch: 'main',
+      model: 'claude-sonnet-4-5',
+      started_at: '2026-03-01T10:00:00.000Z',
+      ended_at: '2026-03-01T10:05:00.000Z',
+      duration_ms: 300000,
+      turn_count: 6,
+      lines: 6,
+      slug: 'test-slug-fixture',
+      first_user_prompt: { turn: 1, snippet: 'Hello, please help me' },
+      last_assistant_text: { turn: 6, snippet: 'I see the edit failed. Let me try a different approach.' },
+      tool_counts: { Grep: 1, Edit: 1 },
+      files_touched: { read: 0, edit: 1, write: 0, grep: 1, glob: 0 },
+    });
+    expect(result.data.subagents.map((s: any) => s.agent_id)).toContain(SUBAGENT_ID);
+    expect(result.data.tool_counts).not.toHaveProperty('Task');
+  });
+
+  test('returns subagent-target summary with agent_id and no nested subagents', async () => {
+    const { exitCode, stdout } = await runCli(['summary', `${SESSION_ID}:${SUBAGENT_ID}`, '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.session_id).toBe(SESSION_ID);
+    expect(result.data.agent_id).toBe(SUBAGENT_ID);
+    expect(result.data.turn_count).toBe(2);
+    expect(result.data.first_user_prompt).toEqual({ turn: 1, snippet: 'Subagent task' });
+    expect(result.data.last_assistant_text).toEqual({ turn: 2, snippet: 'Subagent response' });
+    expect(result.data.subagents).toEqual([]);
+  });
+});
+
 describe('tools integration', () => {
   test('returns all tool calls', async () => {
     const { stdout } = await runCli(['tools', SESSION_ID, '--project', FAKE_PROJECT]);
@@ -1952,6 +2382,48 @@ describe('tools integration', () => {
     const result = parseOutput(stdout);
     expect(result.data.tool_calls.length).toBe(1);
     expect(result.data.tool_calls[0].tool).toBe('Edit');
+  });
+
+  test('filters by --name-match', async () => {
+    const { stdout } = await runCli(['tools', SESSION_ID_4, '--project', FAKE_PROJECT, '--name-match', 'rea']);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.tool_calls.map((call: any) => call.tool)).toEqual(['Read', 'Read']);
+  });
+
+  test('filters by raw --input-match beyond input_summary', async () => {
+    const { stdout } = await runCli(['tools', SESSION_ID_4, '--project', FAKE_PROJECT, '--name', 'Bash', '--input-match', 'raw-bash-marker-after-summary']);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.tool_calls).toHaveLength(1);
+    expect(result.data.tool_calls[0]).toMatchObject({
+      tool: 'Bash',
+      input_summary: expect.not.stringContaining('raw-bash-marker-after-summary'),
+    });
+    expect(result.data.tool_calls[0]).not.toHaveProperty('raw_input');
+  });
+
+  test('filters by --input-regex over raw structured input', async () => {
+    const { stdout } = await runCli(['tools', SESSION_ID_4, '--project', FAKE_PROJECT, '--input-regex', 'raw write content marker']);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.tool_calls).toHaveLength(1);
+    expect(result.data.tool_calls[0].tool).toBe('Write');
+  });
+
+  test('rejects invalid tools regex and mutually exclusive filters', async () => {
+    const invalidRegex = parseOutput((await runCli(['tools', SESSION_ID, '--project', FAKE_PROJECT, '--input-regex', '['])).stdout);
+    expect(invalidRegex.ok).toBe(false);
+    expect(invalidRegex.error.code).toBe('INVALID_ARGS');
+    expect(invalidRegex.error.message).toContain('Invalid --input-regex regex');
+
+    const nameConflict = parseOutput((await runCli(['tools', SESSION_ID, '--project', FAKE_PROJECT, '--name', 'Read', '--name-match', 're'])).stdout);
+    expect(nameConflict.ok).toBe(false);
+    expect(nameConflict.error.code).toBe('INVALID_ARGS');
+
+    const inputConflict = parseOutput((await runCli(['tools', SESSION_ID, '--project', FAKE_PROJECT, '--input-match', 'x', '--input-regex', 'x'])).stdout);
+    expect(inputConflict.ok).toBe(false);
+    expect(inputConflict.error.code).toBe('INVALID_ARGS');
   });
 
   test('filters by --failed', async () => {
@@ -2034,6 +2506,23 @@ describe('messages integration', () => {
     const userMsg = result.data.messages.find((m: any) => m.n === 1);
     expect(userMsg.content[0].text).toContain('...[truncated,');
   });
+
+  test('single-turn text and thinking are unbounded by default while tool results remain bounded', async () => {
+    const textResult = parseOutput((await runCli(['messages', SESSION_ID_5, '--project', FAKE_PROJECT, '--turn', '1'])).stdout);
+    expect(textResult.data.messages[0].content[0].text).toBe('x'.repeat(8300));
+
+    const thinkingResult = parseOutput((await runCli(['messages', SESSION_ID_3, '--project', FAKE_PROJECT, '--turn', '2', '--type', 'thinking'])).stdout);
+    expect(thinkingResult.data.messages[0].content[0].text).toBe(`Considering the approach... ${'x'.repeat(260)}`);
+
+    const toolResult = parseOutput((await runCli(['messages', SESSION_ID_5, '--project', FAKE_PROJECT, '--turn', '1-2'])).stdout);
+    expect(toolResult.data.messages[0].content[0].text).toContain('...[truncated, 8300 chars]');
+  });
+
+  test('--max-tool-result bounds tool results independently from single-turn text', async () => {
+    const { stdout } = await runCli(['messages', SESSION_ID, '--project', FAKE_PROJECT, '--turn', '3', '--max-tool-result', '5']);
+    const result = parseOutput(stdout);
+    expect(result.data.messages[0].content[0].content).toBe('src/h...[truncated, 30 chars]');
+  });
 });
 
 describe('slice integration', () => {
@@ -2056,6 +2545,13 @@ describe('slice integration', () => {
     const thinking = blocks.find((b: any) => b.type === 'thinking');
     expect(thinking.thinking).toContain('...[truncated,');
   });
+
+  test('applies explicit slice truncation policy including zero', async () => {
+    const { stdout } = await runCli(['slice', SESSION_ID_5, '--project', FAKE_PROJECT, '--turn', '1', '--max-content', '0']);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.entries[0].message.content).toBe('...[truncated, 8300 chars]');
+  });
 });
 
 // ============================================================================
@@ -2074,6 +2570,126 @@ describe('userAssistantEntries', () => {
     expect(result.length).toBe(2);
     expect(result[0]!.type).toBe('user');
     expect(result[1]!.type).toBe('assistant');
+  });
+});
+
+// ============================================================================
+// transcript module foundation
+// ============================================================================
+
+describe('transcript module foundation', () => {
+  test('contentBlocksForEntry normalizes string-shaped content into text blocks', () => {
+    expect(contentBlocksForEntry({
+      type: 'user',
+      message: { role: 'user', content: 'plain prompt text' },
+    })).toEqual([{ type: 'text', text: 'plain prompt text' }]);
+  });
+
+  test('contentBlocksForEntry preserves array-shaped content', () => {
+    const blocks = [{ type: 'text' as const, text: 'array prompt' }];
+    expect(contentBlocksForEntry({ type: 'user', message: { content: blocks } })).toBe(blocks);
+  });
+
+  test('normalizedBlocks numbers only user and assistant turns', () => {
+    const entries = [
+      { type: 'system' as const, timestamp: '2026-01-01T00:00:00Z' },
+      { type: 'user' as const, timestamp: '2026-01-01T00:00:01Z', message: { content: 'first' } },
+      { type: 'summary' as const },
+      {
+        type: 'assistant' as const,
+        timestamp: '2026-01-01T00:00:02Z',
+        message: { content: [{ type: 'thinking' as const, thinking: 'hmm' }, { type: 'text' as const, text: 'second' }] },
+      },
+    ];
+
+    expect(normalizedBlocks(entries)).toEqual([
+      {
+        turn: 1,
+        block_index: 0,
+        role: 'user',
+        timestamp: '2026-01-01T00:00:01Z',
+        block: { type: 'text', text: 'first' },
+      },
+      {
+        turn: 2,
+        block_index: 0,
+        role: 'assistant',
+        timestamp: '2026-01-01T00:00:02Z',
+        block: { type: 'thinking', thinking: 'hmm' },
+      },
+      {
+        turn: 2,
+        block_index: 1,
+        role: 'assistant',
+        timestamp: '2026-01-01T00:00:02Z',
+        block: { type: 'text', text: 'second' },
+      },
+    ]);
+  });
+
+  test('extractSessionMetadata returns bounded model metadata from transcript module', () => {
+    const text = [
+      JSON.stringify({ type: 'system', sessionId: 's1', gitBranch: 'main', timestamp: '2026-01-01T00:00:00Z', version: '1.2.3' }),
+      JSON.stringify({ type: 'assistant', message: { model: 'claude-opus-4-1', content: [] }, slug: 'model-test' }),
+    ].join('\n');
+
+    expect(extractTranscriptSessionMetadata(text)).toEqual({
+      branch: 'main',
+      timestamp: '2026-01-01T00:00:00Z',
+      version: '1.2.3',
+      slug: 'model-test',
+      model: 'claude-opus-4-1',
+    });
+  });
+
+  test('resolveSessionWithText returns raw text, filtered entries, metadata, and line count', async () => {
+    const result = await resolveSessionWithText({
+      session: SESSION_ID,
+      project: FAKE_PROJECT,
+      claudeProjectsRoot: FIXTURE_CLAUDE_PROJECTS_ROOT,
+    });
+
+    expect(result.sessionId).toBe(SESSION_ID);
+    expect(result.agentId).toBeNull();
+    expect(result.filePath).toBe(join(CLAUDE_DIR, `${SESSION_ID}.jsonl`));
+    expect(result.text.length).toBeGreaterThan(0);
+    expect(result.allEntries.length).toBeGreaterThanOrEqual(result.entries.length);
+    expect(result.entries.every(e => e.type === 'user' || e.type === 'assistant')).toBe(true);
+    expect(result.lineCount).toBe(result.text.trim().split('\n').length);
+    expect(result.metadata.branch).toBe('main');
+  });
+
+  test('applyTruncationPolicy centralizes per-kind max character behavior', () => {
+    expect(applyTruncationPolicy('hello world', { textMaxChars: 5 }, 'text'))
+      .toBe('hello...[truncated, 11 chars]');
+    expect(applyTruncationPolicy('hello world', { textMaxChars: null }, 'text'))
+      .toBe('hello world');
+    expect(applyTruncationPolicy('abcdef', { defaultMaxChars: 3 }, 'thinking'))
+      .toBe('abc...[truncated, 6 chars]');
+  });
+});
+
+describe('project-selection module foundation', () => {
+  test('module project scope helpers preserve existing target shape', () => {
+    const unique = `cc-session-tool-module-target-${Date.now()}`;
+    const root = join(tmpdir(), unique, '.claude', 'projects');
+    const projectPath = join(tmpdir(), unique, 'repo');
+    const claudeDir = join(root, mangleProjectPathModule(projectPath));
+    const session = '11111111-2222-3333-4444-555555555555';
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, `${session}.jsonl`), JSON.stringify({ type: 'user' }) + '\n');
+
+    try {
+      const context = buildScopedSearchScopeModule({ projectPath, claudeProjectsRoot: root, includeWorktrees: false }).projects[0]!;
+      expect(listSearchTargetsForContextModule(context)).toEqual([{
+        filePath: join(claudeDir, `${session}.jsonl`),
+        sessionId: session,
+        context,
+        projectRef: context.projectRef,
+      }]);
+    } finally {
+      rmSync(join(tmpdir(), unique), { recursive: true, force: true });
+    }
   });
 });
 
@@ -2468,13 +3084,13 @@ describe('extractSessionMetadata', () => {
   test('extracts all fields from valid first entry', () => {
     const text = JSON.stringify({ type: 'system', sessionId: 's1', gitBranch: 'main', timestamp: '2025-01-01T00:00:00Z', version: '1.0' });
     const meta = extractSessionMetadata(text);
-    expect(meta).toEqual({ branch: 'main', timestamp: '2025-01-01T00:00:00Z', version: '1.0', slug: null });
+    expect(meta).toEqual({ branch: 'main', timestamp: '2025-01-01T00:00:00Z', version: '1.0', slug: null, model: null });
   });
 
   test('returns all nulls when no sessionId in first 5 lines', () => {
     const lines = Array.from({ length: 5 }, (_, i) => JSON.stringify({ type: 'user', message: { content: `msg${i}` } }));
     const meta = extractSessionMetadata(lines.join('\n'));
-    expect(meta).toEqual({ branch: null, timestamp: null, version: null, slug: null });
+    expect(meta).toEqual({ branch: null, timestamp: null, version: null, slug: null, model: null });
   });
 
   test('finds slug deeper in text via regex', () => {
@@ -2969,6 +3585,46 @@ describe('search integration', () => {
     expect(worktreeMatch.project_role).toBe('worktree');
   });
 
+  test('search includes subagent transcript text under parent session by default', async () => {
+    const { exitCode, stdout } = await runCli(['search', '--text', 'Subagent response', '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    const match = result.data.find((s: any) => s.session_id === SESSION_ID);
+    expect(match).toBeDefined();
+    expect(match.session_ref).toEqual({
+      session_id: SESSION_ID,
+      project: fakeDirName,
+    });
+    expect(match.matches.evidence.find((e: any) => e.kind === 'text' && e.is_subagent)).toMatchObject({
+      kind: 'text',
+      agent_id: SUBAGENT_ID,
+      parent_session_id: SESSION_ID,
+      is_subagent: true,
+      snippet: expect.stringContaining('Subagent response'),
+    });
+  });
+
+  test('search --no-subagents excludes subagent transcript matches', async () => {
+    const { exitCode, stdout } = await runCli(['search', '--text', 'Subagent response', '--no-subagents', '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.find((s: any) => s.session_id === SESSION_ID)).toBeUndefined();
+  });
+
+  test('parent and subagent evidence can satisfy one grouped search match', async () => {
+    const { exitCode, stdout } = await runCli(['search', '--tool', 'Grep', '--text', 'Subagent response', '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    const match = result.data.find((s: any) => s.session_id === SESSION_ID);
+    expect(match).toBeDefined();
+    expect(match.matches.tools).toContain('Grep');
+    expect(match.matches.evidence.find((e: any) => e.kind === 'tool_input' && e.tool === 'Grep')).toBeDefined();
+    expect(match.matches.evidence.find((e: any) => e.kind === 'text' && e.is_subagent)).toBeDefined();
+  });
+
   test('malformed file tool input does not suppress unrelated tool search matches', async () => {
     const { exitCode, stdout } = await runCli(['search', '--tool', 'Bash', '--input-match', 'malformed-file-input-survives', '--project', RELATED_PROJECT]);
     expect(exitCode).toBe(0);
@@ -2997,11 +3653,14 @@ describe('search integration', () => {
     expect(result.ok).toBe(true);
 
     const writer = result.data.find((s: any) => s.session_id === SESSION_ID_8);
-    expect(writer.matches.file_evidence).toEqual([{
+    expect(writer.matches).not.toHaveProperty('file_evidence');
+    expect(writer.matches.evidence.filter((e: any) => e.kind === 'file')).toEqual([{
+      kind: 'file',
       rawPath: join(RELATED_WORKTREE_ROOT, RELATED_PROJECT_FILE),
       logicalPath: RELATED_PROJECT_FILE,
       operation: 'write',
       turn: 2,
+      block_index: 0,
       timestamp: '2026-03-08T10:01:00.000Z',
     }]);
   });
@@ -3016,7 +3675,7 @@ describe('search integration', () => {
     expect(result._meta.returned).toBe(1);
     expect(result._meta.hasMore).toBe(true);
     expect(result.data[0].matches.operations).toEqual(['write']);
-    expect(result.data[0].matches.file_evidence[0]).toMatchObject({
+    expect(result.data[0].matches.evidence.find((e: any) => e.kind === 'file')).toMatchObject({
       rawPath: join(RELATED_WORKTREE_ROOT, RELATED_PROJECT_FILE),
       logicalPath: RELATED_PROJECT_FILE,
       operation: 'write',
@@ -3034,7 +3693,7 @@ describe('search integration', () => {
   });
 
   test('--origin still applies additional candidate filters before earliest-write ordering', async () => {
-    const { exitCode, stdout } = await runCli(['search', '--file', join(RELATED_PROJECT, RELATED_PROJECT_FILE), '--origin', '--text', 'response', '--project', RELATED_PROJECT]);
+    const { exitCode, stdout } = await runCli(['search', '--file', join(RELATED_PROJECT, RELATED_PROJECT_FILE), '--origin', '--text', 'no matching response phrase', '--project', RELATED_PROJECT]);
     expect(exitCode).toBe(0);
     const result = parseOutput(stdout);
     expect(result.ok).toBe(true);
@@ -3094,6 +3753,17 @@ describe('search integration', () => {
     const match = result.data.find((s: any) => s.session_id === SESSION_ID);
     expect(match).toBeDefined();
     expect(match.matches.turns.length).toBeGreaterThanOrEqual(1);
+    expect(match.matches.evidence.find((e: any) => e.kind === 'text')).toMatchObject({
+      kind: 'text',
+      role: 'assistant',
+      turn: 6,
+      snippet: expect.stringContaining('different approach'),
+    });
+    expect(match.session_ref).toEqual({
+      session_id: SESSION_ID,
+      project: fakeDirName,
+    });
+    expect(match.model).toBe('claude-sonnet-4-5');
   });
 
   test('--text "think about this carefully" finds session (matches thinking block)', async () => {
@@ -3105,6 +3775,57 @@ describe('search integration', () => {
     expect(match.matches.turns.length).toBeGreaterThanOrEqual(1);
   });
 
+  test('--text searches string user content and array user text blocks by default', async () => {
+    const stringUser = parseOutput((await runCli(['search', '--text', 'please help me', '--project', FAKE_PROJECT])).stdout);
+    expect(stringUser.ok).toBe(true);
+    const stringMatch = stringUser.data.find((s: any) => s.session_id === SESSION_ID);
+    expect(stringMatch).toBeDefined();
+    expect(stringMatch.matches.evidence.find((e: any) => e.kind === 'text' && e.role === 'user')).toMatchObject({
+      kind: 'text',
+      role: 'user',
+      turn: 1,
+      snippet: expect.stringContaining('please help me'),
+    });
+
+    const arrayUser = parseOutput((await runCli(['search', '--text', 'array content marker', '--text-role', 'user', '--project', FAKE_PROJECT])).stdout);
+    expect(arrayUser.ok).toBe(true);
+    const arrayMatch = arrayUser.data.find((s: any) => s.session_id === SESSION_ID_2);
+    expect(arrayMatch).toBeDefined();
+    expect(arrayMatch.matches.evidence.find((e: any) => e.kind === 'text' && e.role === 'user')).toMatchObject({
+      kind: 'text',
+      role: 'user',
+      turn: 1,
+      block_index: 0,
+    });
+  });
+
+  test('--text-regex matches text and invalid text regex returns INVALID_ARGS', async () => {
+    const { exitCode, stdout } = await runCli(['search', '--text-regex', 'different\\s+approach', '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.map((s: any) => s.session_id)).toContain(SESSION_ID);
+
+    const invalid = parseOutput((await runCli(['search', '--text-regex', '[', '--project', FAKE_PROJECT])).stdout);
+    expect(invalid.ok).toBe(false);
+    expect(invalid.error.code).toBe('INVALID_ARGS');
+    expect(invalid.error.message).toContain('Invalid --text-regex regex');
+  });
+
+  test('--intent-match /plan emits intent evidence', async () => {
+    const { exitCode, stdout } = await runCli(['search', '--intent-match', '/plan', '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    const match = result.data.find((s: any) => s.session_id === SESSION_ID_3);
+    expect(match).toBeDefined();
+    expect(match.matches.evidence.find((e: any) => e.kind === 'intent')).toMatchObject({
+      kind: 'intent',
+      intent_source: 'first_message',
+      snippet: expect.stringContaining('/plan'),
+    });
+  });
+
   test('--bash "npm install" finds Bash fixture session', async () => {
     const { stdout } = await runCli(['search', '--bash', 'npm install', '--project', FAKE_PROJECT]);
     const result = parseOutput(stdout);
@@ -3112,6 +3833,21 @@ describe('search integration', () => {
     const match = result.data.find((s: any) => s.session_id === SESSION_ID_4);
     expect(match).toBeDefined();
     expect(match.matches.turns.length).toBeGreaterThanOrEqual(1);
+    expect(match.matches.evidence.find((e: any) => e.kind === 'bash')).toMatchObject({
+      kind: 'bash',
+      tool: 'Bash',
+      snippet: expect.stringContaining('npm install'),
+    });
+  });
+
+  test('--bash-regex and --input-regex match raw structured values', async () => {
+    const bash = parseOutput((await runCli(['search', '--bash-regex', 'npm\\s+install', '--project', FAKE_PROJECT])).stdout);
+    expect(bash.ok).toBe(true);
+    expect(bash.data.map((s: any) => s.session_id)).toContain(SESSION_ID_4);
+
+    const input = parseOutput((await runCli(['search', '--tool', 'Write', '--input-regex', 'raw write content marker', '--project', FAKE_PROJECT])).stdout);
+    expect(input.ok).toBe(true);
+    expect(input.data.map((s: any) => s.session_id)).toContain(SESSION_ID_4);
   });
 
   test('--input-match searches raw Bash commands beyond input summary truncation', async () => {
@@ -3122,10 +3858,15 @@ describe('search integration', () => {
     expect(result.data.map((s: any) => s.session_id)).toContain(SESSION_ID_4);
     const match = result.data.find((s: any) => s.session_id === SESSION_ID_4);
     expect(match.matches.tools).toEqual(['Bash']);
-    expect(match.matches.tool_inputs).toEqual([{
+    expect(match.matches).not.toHaveProperty('tool_inputs');
+    expect(match.matches.evidence.filter((e: any) => e.kind === 'tool_input')).toMatchObject([{
+      kind: 'tool_input',
       tool: 'Bash',
       input_summary: expect.not.stringContaining('raw-bash-marker-after-summary'),
+      snippet: expect.stringContaining('raw-bash-marker-after-summary'),
       turn: 2,
+      block_index: 0,
+      timestamp: '2026-03-04T10:01:00.000Z',
     }]);
   });
 
@@ -3133,7 +3874,8 @@ describe('search integration', () => {
     const editResult = parseOutput((await runCli(['search', '--tool', 'Edit', '--input-match', 'legacy raw old marker', '--project', FAKE_PROJECT])).stdout);
     expect(editResult.ok).toBe(true);
     expect(editResult.data.map((s: any) => s.session_id)).toContain(SESSION_ID);
-    expect(editResult.data.find((s: any) => s.session_id === SESSION_ID).matches.tool_inputs[0]).toEqual({
+    expect(editResult.data.find((s: any) => s.session_id === SESSION_ID).matches.evidence.find((e: any) => e.kind === 'tool_input')).toMatchObject({
+      kind: 'tool_input',
       tool: 'Edit',
       input_summary: "file='hello.ts' old=(21 chars) new=(26 chars)",
       turn: 4,
@@ -3150,10 +3892,14 @@ describe('search integration', () => {
     const result = parseOutput(stdout);
     expect(result.ok).toBe(true);
     expect(result.data.map((s: any) => s.session_id)).toEqual([SESSION_ID_2]);
-    expect(result.data[0].matches.tool_inputs).toEqual([{
+    expect(result.data[0].matches.evidence.filter((e: any) => e.kind === 'tool_input')).toMatchObject([{
+      kind: 'tool_input',
       tool: 'TodoWrite',
       input_summary: expect.stringContaining('stable json audit marker'),
+      snippet: expect.stringContaining('stable json audit marker'),
       turn: 2,
+      block_index: 0,
+      timestamp: '2026-03-02T10:01:00.000Z',
     }]);
   });
 
@@ -3220,16 +3966,143 @@ describe('search integration', () => {
     ]);
   });
 
+  test('--aggregate counters uses counters as selector and returns nonzero rows', async () => {
+    const { exitCode, stdout } = await runCli(['search', '--counter', 'tracking=.claude-tracking', '--aggregate', 'counters', '--project', FAKE_PROJECT]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result.data.map((s: any) => s.session_id)).toContain(SESSION_ID_4);
+    const aggregate = result.data.find((s: any) => s.session_id === SESSION_ID_4);
+    expect(aggregate).toMatchObject({
+      session_id: SESSION_ID_4,
+      project: basename(CLAUDE_DIR),
+      project_path_guess: null,
+      project_role: 'main',
+      session_ref: { session_id: SESSION_ID_4, project: basename(CLAUDE_DIR) },
+      counts: { tracking: 1 },
+      total_matches: 1,
+    });
+    expect(result.data.every((row: any) => row.total_matches > 0)).toBe(true);
+  });
+
+  test('--aggregate counters preserves selected zero-count rows and supports bucket day', async () => {
+    const { exitCode, stdout } = await runCli([
+      'search',
+      '--tool', 'Read',
+      '--counter', 'missing=no-such-counter-marker',
+      '--aggregate', 'counters',
+      '--bucket', 'day',
+      '--project', FAKE_PROJECT,
+    ]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    const day = result.data.find((bucket: any) => bucket.bucket === '2026-03-04');
+    expect(day).toEqual({
+      bucket: '2026-03-04',
+      sessions: 1,
+      counts: { missing: 0 },
+      total_matches: 0,
+    });
+  });
+
+  test('--aggregate counters supports regex counters, week buckets, and all-project audit shape', async () => {
+    const { exitCode, stdout } = await runCli([
+      'search',
+      '--all-projects',
+      '--project-glob', '*fake-project-worktree',
+      '--tool', 'Write',
+      '--input-match', 'cross audit content marker',
+      '--counter', 'cross=cross audit',
+      '--counter-regex', 'write_file="file_path":".*cross-project',
+      '--aggregate', 'counters',
+      '--bucket', 'week',
+    ]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    expect(result._meta.projects_scanned).toBe(1);
+    expect(result.data).toEqual([
+      {
+        bucket: '2026-03-02',
+        sessions: 1,
+        counts: { cross: 1, write_file: 1 },
+        total_matches: 2,
+      },
+    ]);
+  });
+
+  test('--aggregate counters can roll up subagent Bash evidence selected by parent /plan intent', async () => {
+    const { exitCode, stdout } = await runCli([
+      'search',
+      '--intent-match', '/plan',
+      '--counter', 'tracking=.claude-tracking',
+      '--aggregate', 'counters',
+      '--project', FAKE_PROJECT,
+    ]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    const aggregate = result.data.find((s: any) => s.session_id === SESSION_ID_4);
+    expect(aggregate).toMatchObject({
+      session_id: SESSION_ID_4,
+      counts: { tracking: 1 },
+      total_matches: 1,
+      session_ref: { session_id: SESSION_ID_4, project: basename(CLAUDE_DIR) },
+    });
+  });
+
+  test('--aggregate counters --per-subagent emits transcript-level rows', async () => {
+    const { exitCode, stdout } = await runCli([
+      'search',
+      '--intent-match', '/plan',
+      '--counter', 'tracking=.claude-tracking',
+      '--aggregate', 'counters',
+      '--per-subagent',
+      '--project', FAKE_PROJECT,
+    ]);
+    expect(exitCode).toBe(0);
+    const result = parseOutput(stdout);
+    expect(result.ok).toBe(true);
+    const rows = result.data.filter((s: any) => s.session_id === SESSION_ID_4);
+    const subagentRow = rows.find((s: any) => s.agent_id === 'counter_agent');
+    expect(rows.some((s: any) => s.agent_id === undefined && s.total_matches === 0)).toBe(true);
+    expect(subagentRow).toMatchObject({
+      session_id: SESSION_ID_4,
+      agent_id: 'counter_agent',
+      parent_session_id: SESSION_ID_4,
+      is_subagent: true,
+      session_ref: { session_id: SESSION_ID_4, project: basename(CLAUDE_DIR), agent_id: 'counter_agent' },
+      counts: { tracking: 1 },
+      total_matches: 1,
+    });
+  });
+
   test('--aggregate rejects invalid usage', async () => {
     const withoutToolInput = parseOutput((await runCli(['search', '--file', 'hello.ts', '--aggregate', 'count-per-session', '--project', FAKE_PROJECT])).stdout);
     expect(withoutToolInput.ok).toBe(false);
     expect(withoutToolInput.error.code).toBe('INVALID_ARGS');
-    expect(withoutToolInput.error.message).toContain('--aggregate requires --tool or --input-match');
+    expect(withoutToolInput.error.message).toContain('--aggregate requires --tool, --input-match, or --input-regex');
 
     const invalidMode = parseOutput((await runCli(['search', '--tool', 'Read', '--aggregate', 'totals', '--project', FAKE_PROJECT])).stdout);
     expect(invalidMode.ok).toBe(false);
     expect(invalidMode.error.code).toBe('INVALID_ARGS');
-    expect(invalidMode.error.message).toContain('--aggregate must be count-per-session');
+    expect(invalidMode.error.message).toContain('--aggregate must be one of: count-per-session, counters');
+
+    const countersWithoutAggregate = parseOutput((await runCli(['search', '--counter', 'x=y', '--project', FAKE_PROJECT])).stdout);
+    expect(countersWithoutAggregate.ok).toBe(false);
+    expect(countersWithoutAggregate.error.code).toBe('INVALID_ARGS');
+    expect(countersWithoutAggregate.error.message).toContain('--counter and --counter-regex require --aggregate counters');
+
+    const countersWithoutCounter = parseOutput((await runCli(['search', '--tool', 'Read', '--aggregate', 'counters', '--project', FAKE_PROJECT])).stdout);
+    expect(countersWithoutCounter.ok).toBe(false);
+    expect(countersWithoutCounter.error.code).toBe('INVALID_ARGS');
+    expect(countersWithoutCounter.error.message).toContain('--aggregate counters requires at least one --counter or --counter-regex');
+
+    const bucketWithoutCounters = parseOutput((await runCli(['search', '--tool', 'Read', '--aggregate', 'count-per-session', '--bucket', 'day', '--project', FAKE_PROJECT])).stdout);
+    expect(bucketWithoutCounters.ok).toBe(false);
+    expect(bucketWithoutCounters.error.code).toBe('INVALID_ARGS');
+    expect(bucketWithoutCounters.error.message).toContain('--bucket requires --aggregate counters');
   });
 
   test('--tool Grep --branch main combines content + metadata filters', async () => {

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ import {
   extractWorktreeStatePaths as projectExtractWorktreeStatePaths,
   findRelatedProjectRefs as projectFindRelatedProjectRefs,
   isPathWithinOrEqual as projectIsPathWithinOrEqual,
+  isProjectSelectionError as projectIsProjectSelectionError,
   listClaudeProjectRefs as projectListClaudeProjectRefs,
   listSearchTargetsForContext as projectListSearchTargetsForContext,
   mangleProjectPath as projectMangleProjectPath,
@@ -476,6 +477,14 @@ export function isCliError(err: unknown): err is CliError {
   return err instanceof CliError;
 }
 
+function mapProjectSelectionError(err: unknown, fallbackCode: ErrorCode): never {
+  if (projectIsProjectSelectionError(err)) {
+    throw cliError(err.code, err.message);
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  throw cliError(fallbackCode, message);
+}
+
 function handleCommandError(err: unknown): void {
   if (isCliError(err)) {
     output(failure(err.errorCode, err.message));
@@ -526,8 +535,7 @@ export function buildScopedSearchScope(options: SearchScopeOptions): SearchScope
   try {
     return projectBuildScopedSearchScope(options);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw cliError('NOT_FOUND', message);
+    mapProjectSelectionError(err, 'NOT_FOUND');
   }
 }
 
@@ -535,8 +543,7 @@ export function selectProjectContexts(options: ProjectSelectionOptions): Project
   try {
     return projectSelectProjectContexts(options);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw cliError('NOT_FOUND', message);
+    mapProjectSelectionError(err, 'NOT_FOUND');
   }
 }
 
@@ -544,8 +551,7 @@ export function resolveClaudeProjectDir(projectPath: string, root = claudeProjec
   try {
     return projectResolveClaudeProjectDir(projectPath, root);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw cliError('NOT_FOUND', message);
+    mapProjectSelectionError(err, 'NOT_FOUND');
   }
 }
 
@@ -553,8 +559,7 @@ function validateClaudeProjectBasename(project: string): void {
   try {
     projectValidateClaudeProjectBasename(project);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw cliError('INVALID_ARGS', message);
+    mapProjectSelectionError(err, 'INVALID_ARGS');
   }
 }
 
@@ -565,9 +570,7 @@ export function resolveClaudeProjectDirFromSelector(
   try {
     return projectResolveClaudeProjectDirFromSelector(selector, root);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message.includes('--claude-project')) throw cliError('INVALID_ARGS', message);
-    throw cliError('NOT_FOUND', message);
+    mapProjectSelectionError(err, 'NOT_FOUND');
   }
 }
 
@@ -578,8 +581,7 @@ function sessionProjectSelectorFromArgs(args: {
   try {
     return projectSessionProjectSelectorFromArgs(args);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw cliError('INVALID_ARGS', message);
+    mapProjectSelectionError(err, 'INVALID_ARGS');
   }
 }
 
@@ -1556,7 +1558,7 @@ const summaryCommand = defineCommand({
       const result: SessionSummaryResult = buildSessionSummary({
         sessionId: resolved.sessionId,
         agentId: resolved.agentId,
-        entries: resolved.entries,
+        entries: resolved.allEntries,
         metadata: resolved.metadata,
         lineCount: resolved.lineCount,
         subagents,

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,34 @@
 #!/usr/bin/env bun
 import { defineCommand, runMain } from 'citty';
-import { homedir } from 'os';
-import { join, basename, dirname, resolve, relative, isAbsolute } from 'path';
-import { readdirSync, existsSync, realpathSync } from 'fs';
+import { join, basename, dirname } from 'path';
+import { readdirSync, existsSync } from 'fs';
+import {
+  absolutePathCandidatesFor as projectAbsolutePathCandidatesFor,
+  buildScopedSearchScope as projectBuildScopedSearchScope,
+  buildSearchSessionContext as projectBuildSearchSessionContext,
+  claudeProjectsRoot as projectClaudeProjectsRoot,
+  collectObservedWorktreeRoots as projectCollectObservedWorktreeRoots,
+  deriveWorktreeRootFromPath as projectDeriveWorktreeRootFromPath,
+  extractSessionCwd as projectExtractSessionCwd,
+  extractWorktreeStatePaths as projectExtractWorktreeStatePaths,
+  findRelatedProjectRefs as projectFindRelatedProjectRefs,
+  isPathWithinOrEqual as projectIsPathWithinOrEqual,
+  listClaudeProjectRefs as projectListClaudeProjectRefs,
+  listSearchTargetsForContext as projectListSearchTargetsForContext,
+  mangleProjectPath as projectMangleProjectPath,
+  matchFileAccess as projectMatchFileAccess,
+  normalizeFileAccess as projectNormalizeFileAccess,
+  normalizeFileQuery as projectNormalizeFileQuery,
+  normalizePathForContainment as projectNormalizePathForContainment,
+  pathContainmentCandidates as projectPathContainmentCandidates,
+  projectMatchesGlob as projectProjectMatchesGlob,
+  projectPathGuessFromClaudeProject as projectProjectPathGuessFromClaudeProject,
+  resolveClaudeProjectDir as projectResolveClaudeProjectDir,
+  resolveClaudeProjectDirFromSelector as projectResolveClaudeProjectDirFromSelector,
+  selectProjectContexts as projectSelectProjectContexts,
+  sessionProjectSelectorFromArgs as projectSessionProjectSelectorFromArgs,
+  validateClaudeProjectBasename as projectValidateClaudeProjectBasename,
+} from './src/project-selection.ts';
 import {
   aggregateCounterRows,
   attachCounterTranscriptResults,
@@ -473,467 +499,88 @@ for (const signal of ['SIGTERM', 'SIGINT'] as const) {
 // Session Helpers
 // ============================================================================
 
-/**
- * Convert an absolute project path to the Claude projects directory.
- * /Users/jane/foo → ~/.claude/projects/-Users-jane-foo
- */
-export function claudeProjectsRoot(home = homedir()): string {
-  return join(home, '.claude', 'projects');
-}
-
-export function mangleProjectPath(projectPath: string): string {
-  const normalized = normalizePathForContainment(projectPath);
-  const stripped = normalized.startsWith('/') ? normalized.slice(1) : normalized;
-  return '-' + stripped.replace(/\//g, '-');
-}
-
-export function projectPathGuessFromClaudeProject(projectName: string): string | null {
-  if (!projectName.startsWith('-')) return null;
-  return '/' + projectName.slice(1).replace(/-/g, '/');
-}
-
-export function listClaudeProjectRefs(root = claudeProjectsRoot()): ProjectRef[] {
-  if (!existsSync(root)) return [];
-  return readdirSync(root, { withFileTypes: true })
-    .filter(d => d.isDirectory())
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .map(d => ({
-      project: d.name,
-      claude_dir: join(root, d.name),
-      project_path_guess: projectPathGuessFromClaudeProject(d.name),
-    }));
-}
-
-function stripTrailingSlashes(input: string): string {
-  return input.replace(/\/+$/, '') || '/';
-}
-
-export function normalizePathForContainment(input: string): string {
-  return stripTrailingSlashes(resolve(input));
-}
-
-export function isPathWithinOrEqual(pathname: string, root: string): boolean {
-  const normalizedPath = normalizePathForContainment(pathname);
-  const normalizedRoot = normalizePathForContainment(root);
-  const rel = relative(normalizedRoot, normalizedPath);
-  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
-}
-
-export function pathContainmentCandidates(pathname: string): string[] {
-  const candidates = new Set<string>([normalizePathForContainment(pathname)]);
-  try {
-    candidates.add(normalizePathForContainment(realpathSync.native(pathname)));
-  } catch {
-    // Missing fixture paths are common in transcript tests; keep the lexical candidate.
-  }
-  let existingAncestor = normalizePathForContainment(pathname);
-  const missingSegments: string[] = [];
-  while (!existsSync(existingAncestor)) {
-    const parent = dirname(existingAncestor);
-    if (parent === existingAncestor) break;
-    missingSegments.unshift(basename(existingAncestor));
-    existingAncestor = parent;
-  }
-  if (existsSync(existingAncestor)) {
-    try {
-      candidates.add(normalizePathForContainment(join(realpathSync.native(existingAncestor), ...missingSegments)));
-    } catch {
-      // Keep the candidates collected so far.
-    }
-  }
-  return Array.from(candidates);
-}
-
-function uniqueNormalizedCandidates(paths: Array<string | null | undefined>): string[] {
-  const candidates = new Set<string>();
-  for (const pathname of paths) {
-    if (!pathname || !isAbsolute(pathname)) continue;
-    for (const candidate of pathContainmentCandidates(pathname)) {
-      candidates.add(candidate);
-    }
-  }
-  return Array.from(candidates);
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
-
-function normalizeLogicalRelativePath(pathname: string): string {
-  return pathname.split('/').filter(part => part.length > 0).join('/');
-}
-
-function logicalPathForAbsoluteCandidates(candidates: string[], roots: string[]): string | null {
-  const orderedRoots = [...roots].sort((a, b) => b.length - a.length);
-  for (const candidate of candidates) {
-    for (const root of orderedRoots) {
-      if (!isPathWithinOrEqual(candidate, root)) continue;
-      const rel = relative(root, candidate);
-      if (!rel || rel.startsWith('..') || isAbsolute(rel)) continue;
-      return normalizeLogicalRelativePath(rel);
-    }
-  }
-  return null;
-}
-
-export function absolutePathCandidatesFor(pathname: string, context: SearchSessionContext): string[] {
-  if (!isAbsolute(pathname)) return [];
-  const cached = context.pathCandidateCache.get(pathname);
-  if (cached) return cached;
-  const candidates = pathContainmentCandidates(pathname);
-  context.pathCandidateCache.set(pathname, candidates);
-  return candidates;
-}
-
-export function deriveWorktreeRootFromPath(projectRoot: string | null, pathname: string | null): string | null {
-  if (!projectRoot || !pathname || !isAbsolute(pathname)) return null;
-
-  for (const projectCandidate of pathContainmentCandidates(projectRoot)) {
-    const worktreesRoot = normalizePathForContainment(join(projectCandidate, '.claude', 'worktrees'));
-    for (const pathCandidate of pathContainmentCandidates(pathname)) {
-      if (!isPathWithinOrEqual(pathCandidate, worktreesRoot)) continue;
-      const rel = relative(worktreesRoot, pathCandidate);
-      if (!rel || rel.startsWith('..') || isAbsolute(rel)) continue;
-      const [worktreeDir] = rel.split('/');
-      if (!worktreeDir) continue;
-      return normalizePathForContainment(join(worktreesRoot, worktreeDir));
-    }
-  }
-
-  return null;
-}
-
-export function extractSessionCwd(entries: SessionEntry[]): string | null {
-  for (const entry of entries) {
-    if (typeof entry.cwd === 'string' && entry.cwd.trim()) return entry.cwd;
-  }
-  return null;
-}
-
-export function extractWorktreeStatePaths(entries: SessionEntry[]): WorktreeStatePaths {
-  const paths: WorktreeStatePaths = { originalCwd: null, worktreePath: null };
-
-  for (const entry of entries) {
-    const record = entry as unknown as Record<string, unknown>;
-    for (const key of ['worktree-state', 'worktreeState']) {
-      const state = record[key];
-      if (!isRecord(state)) continue;
-      if (paths.originalCwd === null && typeof state.originalCwd === 'string' && state.originalCwd.trim()) {
-        paths.originalCwd = state.originalCwd;
-      }
-      if (paths.worktreePath === null && typeof state.worktreePath === 'string' && state.worktreePath.trim()) {
-        paths.worktreePath = state.worktreePath;
-      }
-    }
-    if (paths.originalCwd !== null && paths.worktreePath !== null) break;
-  }
-
-  return paths;
-}
-
-function equivalentAbsolutePath(a: string | null, b: string | null): boolean {
-  if (!a || !b || !isAbsolute(a) || !isAbsolute(b)) return false;
-  const bCandidates = new Set(pathContainmentCandidates(b));
-  return pathContainmentCandidates(a).some(candidate => bCandidates.has(candidate));
-}
-
-function acceptedProjectRoot(projectRoot: string | null, candidate: string | null): string | null {
-  return equivalentAbsolutePath(projectRoot, candidate) ? candidate : null;
-}
-
-function acceptedWorktreeRoot(projectRoot: string | null, candidate: string | null): string | null {
-  if (!projectRoot || !candidate || !isAbsolute(candidate)) return null;
-  return deriveWorktreeRootFromPath(projectRoot, candidate);
-}
-
-export function collectObservedWorktreeRoots(entries: SessionEntry[], projectRoot: string | null): string[] {
-  const observed = new Set<string>();
-  if (!projectRoot) return [];
-
-  for (const entry of entries) {
-    const content = entry.message?.content;
-    if (!Array.isArray(content)) continue;
-    for (const block of content) {
-      if (block.type !== 'tool_use' || !block.name) continue;
-      const fileInfo = extractFilePath(block.name, block.input ?? {});
-      if (!fileInfo || !isAbsolute(fileInfo.path)) continue;
-      const worktreeRoot = acceptedWorktreeRoot(projectRoot, fileInfo.path);
-      if (worktreeRoot) observed.add(worktreeRoot);
-    }
-  }
-
-  return Array.from(observed);
-}
-
-export function buildSearchSessionContext(context: SearchProjectContext, entries: SessionEntry[]): SearchSessionContext {
-  const sessionCwd = extractSessionCwd(entries);
-  const worktreeStatePaths = extractWorktreeStatePaths(entries);
-  const queryAnchorRoot = context.queryAnchorRoot ?? null;
-  const identityRoot = context.projectRoot ?? queryAnchorRoot;
-  const projectRootCandidates = [
-    context.projectRoot,
-    queryAnchorRoot,
-    acceptedProjectRoot(identityRoot, sessionCwd),
-    acceptedProjectRoot(identityRoot, worktreeStatePaths.originalCwd),
-  ];
-  const worktreeRootCandidates = [
-    context.worktreeRoot,
-    acceptedWorktreeRoot(identityRoot, sessionCwd),
-    acceptedWorktreeRoot(identityRoot, worktreeStatePaths.originalCwd),
-    acceptedWorktreeRoot(identityRoot, worktreeStatePaths.worktreePath),
-    ...collectObservedWorktreeRoots(entries, identityRoot),
-  ];
-  return {
-    ...context,
-    sessionCwd,
-    worktreeStateOriginalCwd: worktreeStatePaths.originalCwd,
-    worktreeStateWorktreePath: worktreeStatePaths.worktreePath,
-    queryAnchorRoot,
-    normalizedProjectRoots: uniqueNormalizedCandidates(projectRootCandidates),
-    normalizedWorktreeRoots: uniqueNormalizedCandidates(worktreeRootCandidates),
-    pathCandidateCache: new Map<string, string[]>(),
-  };
-}
-
-export function normalizeFileQuery(raw: string, context: SearchSessionContext): NormalizedFileQuery {
-  const absoluteCandidates = absolutePathCandidatesFor(raw, context);
-  const logicalPath = absoluteCandidates.length > 0
-    ? logicalPathForAbsoluteCandidates(absoluteCandidates, context.normalizedProjectRoots)
-    : null;
-  return {
-    raw,
-    rawLower: raw.toLowerCase(),
-    logicalPath,
-    absoluteCandidates,
-  };
-}
-
-export function normalizeFileAccess(
-  rawPath: string,
-  operation: SearchOperation,
-  context: SearchSessionContext,
-): NormalizedFileAccess {
-  const identityRoot = context.projectRoot ?? context.queryAnchorRoot;
-  const observedWorktreeRoot = deriveWorktreeRootFromPath(identityRoot, rawPath);
-  const roots = [
-    ...context.normalizedProjectRoots,
-    ...context.normalizedWorktreeRoots,
-    ...uniqueNormalizedCandidates([observedWorktreeRoot]),
-  ];
-  const absoluteCandidates = absolutePathCandidatesFor(rawPath, context);
-  const logicalPath = absoluteCandidates.length > 0
-    ? logicalPathForAbsoluteCandidates(absoluteCandidates, roots)
-    : null;
-  return { rawPath, operation, logicalPath, absoluteCandidates };
-}
-
-export function matchFileAccess(query: NormalizedFileQuery, access: NormalizedFileAccess): FileMatchResult {
-  if (query.absoluteCandidates.length > 0 && access.absoluteCandidates.length > 0) {
-    const accessCandidates = new Set(access.absoluteCandidates);
-    if (query.absoluteCandidates.some(candidate => accessCandidates.has(candidate))) {
-      return {
-        matched: true,
-        matchedBy: 'canonical',
-        logicalPath: access.logicalPath ?? query.logicalPath,
-      };
-    }
-  }
-
-  if (query.logicalPath != null) {
-    const matched = access.logicalPath === query.logicalPath;
-    return {
-      matched,
-      matchedBy: 'logical',
-      logicalPath: matched ? access.logicalPath : null,
-    };
-  }
-
-  return {
-    matched: access.rawPath.toLowerCase().includes(query.rawLower),
-    matchedBy: 'substring',
-    logicalPath: access.logicalPath,
-  };
-}
-
-export function findRelatedProjectRefs(projectPath: string, refs: ProjectRef[]): ProjectRef[] {
-  const normalizedProject = normalizePathForContainment(projectPath);
-  const worktreesDirPrefix = `${mangleProjectPath(join(normalizedProject, '.claude', 'worktrees'))}-`;
-  const doubleDashWorktreePrefix = `${mangleProjectPath(normalizedProject)}--claude-worktrees-`;
-  const related: ProjectRef[] = [];
-  const seen = new Set<string>();
-
-  for (const ref of refs) {
-    if (!ref.project.startsWith(worktreesDirPrefix) && !ref.project.startsWith(doubleDashWorktreePrefix)) {
-      continue;
-    }
-    if (seen.has(ref.project)) continue;
-    seen.add(ref.project);
-    related.push(ref);
-  }
-
-  return related;
-}
+export const claudeProjectsRoot = projectClaudeProjectsRoot;
+export const mangleProjectPath = projectMangleProjectPath;
+export const projectPathGuessFromClaudeProject = projectProjectPathGuessFromClaudeProject;
+export const listClaudeProjectRefs = projectListClaudeProjectRefs;
+export const normalizePathForContainment = projectNormalizePathForContainment;
+export const isPathWithinOrEqual = projectIsPathWithinOrEqual;
+export const pathContainmentCandidates = projectPathContainmentCandidates;
+export const absolutePathCandidatesFor = projectAbsolutePathCandidatesFor;
+export const deriveWorktreeRootFromPath = projectDeriveWorktreeRootFromPath;
+export const extractSessionCwd = projectExtractSessionCwd;
+export const extractWorktreeStatePaths = projectExtractWorktreeStatePaths;
+export const collectObservedWorktreeRoots = projectCollectObservedWorktreeRoots;
+export const buildSearchSessionContext = projectBuildSearchSessionContext;
+export const normalizeFileQuery = projectNormalizeFileQuery;
+export const normalizeFileAccess = projectNormalizeFileAccess;
+export const matchFileAccess = projectMatchFileAccess;
+export const findRelatedProjectRefs = projectFindRelatedProjectRefs;
+export const projectMatchesGlob = projectProjectMatchesGlob;
+export const listSearchTargetsForContext = projectListSearchTargetsForContext;
 
 export function buildScopedSearchScope(options: SearchScopeOptions): SearchScope {
-  const projectRoot = normalizePathForContainment(options.projectPath);
-  const root = options.claudeProjectsRoot ?? claudeProjectsRoot();
-  const mainProjectRef: ProjectRef = {
-    project: mangleProjectPath(options.projectPath),
-    claude_dir: resolveClaudeProjectDir(options.projectPath, root),
-    project_path_guess: options.projectPath,
-  };
-  const projects: SearchProjectContext[] = [{
-    role: 'main',
-    projectRoot: options.projectPath,
-    worktreeRoot: null,
-    projectRef: mainProjectRef,
-  }];
-
-  if (options.includeWorktrees) {
-    for (const ref of findRelatedProjectRefs(options.projectPath, listClaudeProjectRefs(root))) {
-      projects.push({
-        role: 'worktree',
-        projectRoot: options.projectPath,
-        worktreeRoot: null,
-        projectRef: ref,
-      });
-    }
+  try {
+    return projectBuildScopedSearchScope(options);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw cliError('NOT_FOUND', message);
   }
-
-  return { projectRoot, projects };
-}
-
-function publicProjectRef(context: SearchProjectContext): PublicProjectRef {
-  return {
-    project: context.projectRef.project,
-    project_path_guess: context.projectRef.project_path_guess,
-    project_role: context.role,
-  };
-}
-
-function globToRegExp(glob: string): RegExp {
-  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&');
-  const pattern = escaped.replace(/\*/g, '.*').replace(/\?/g, '.');
-  return new RegExp(`^${pattern}$`);
-}
-
-export function projectMatchesGlob(ref: ProjectRef, glob: string): boolean {
-  return projectMatchesPattern(ref, globToRegExp(glob));
-}
-
-function projectMatchesPattern(ref: ProjectRef, regex: RegExp): boolean {
-  return regex.test(ref.project) || Boolean(ref.project_path_guess && regex.test(ref.project_path_guess));
 }
 
 export function selectProjectContexts(options: ProjectSelectionOptions): ProjectSelection {
-  const root = options.claudeProjectsRoot ?? claudeProjectsRoot();
-
-  if (options.mode === 'all-projects') {
-    const included: SearchProjectContext[] = [];
-    const skipped: SearchProjectContext[] = [];
-    const projectGlobRegex = options.projectGlob ? globToRegExp(options.projectGlob) : null;
-    const queryAnchorRoot = options.projectPath ?? null;
-    for (const projectRef of listClaudeProjectRefs(root)) {
-      const context: SearchProjectContext = {
-        role: 'global',
-        projectRoot: null,
-        worktreeRoot: null,
-        queryAnchorRoot,
-        projectRef,
-      };
-      if (projectGlobRegex && !projectMatchesPattern(projectRef, projectGlobRegex)) {
-        skipped.push(context);
-      } else {
-        included.push(context);
-      }
-    }
-    return {
-      contexts: included,
-      includedProjects: included.map(publicProjectRef),
-      skippedProjects: skipped.map(publicProjectRef),
-    };
+  try {
+    return projectSelectProjectContexts(options);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw cliError('NOT_FOUND', message);
   }
-
-  const projectPath = options.projectPath || process.cwd();
-  const scope = buildScopedSearchScope({
-    projectPath,
-    claudeProjectsRoot: root,
-    includeWorktrees: options.mode === 'scoped-with-worktrees',
-  });
-  return {
-    contexts: scope.projects,
-    includedProjects: scope.projects.map(publicProjectRef),
-    skippedProjects: [],
-  };
 }
 
 export function resolveClaudeProjectDir(projectPath: string, root = claudeProjectsRoot()): string {
-  const claudeDir = join(root, mangleProjectPath(projectPath));
-  if (!existsSync(claudeDir)) {
-    throw cliError('NOT_FOUND', `Claude project directory not found: ${claudeDir}`);
+  try {
+    return projectResolveClaudeProjectDir(projectPath, root);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw cliError('NOT_FOUND', message);
   }
-  return claudeDir;
 }
 
 function validateClaudeProjectBasename(project: string): void {
-  if (
-    !project ||
-    project === '.' ||
-    project === '..' ||
-    project.includes('/') ||
-    project.includes('\\') ||
-    basename(project) !== project
-  ) {
-    throw cliError('INVALID_ARGS', '--claude-project must be a Claude project directory basename');
+  try {
+    projectValidateClaudeProjectBasename(project);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw cliError('INVALID_ARGS', message);
   }
-}
-
-function readRawStringOption(name: string): string | undefined {
-  const longName = `--${name}`;
-  const withEquals = `${longName}=`;
-  for (let i = 2; i < process.argv.length; i++) {
-    const arg = process.argv[i]!;
-    if (arg.startsWith(withEquals)) {
-      return arg.slice(withEquals.length);
-    }
-    if (arg === longName) {
-      const value = process.argv[i + 1];
-      return value && !value.startsWith('--') ? value : undefined;
-    }
-  }
-  return undefined;
 }
 
 export function resolveClaudeProjectDirFromSelector(
   selector: SessionProjectSelector,
   root = claudeProjectsRoot(),
 ): string {
-  if (selector.kind === 'projectPath') {
-    return resolveClaudeProjectDir(selector.projectPath, root);
+  try {
+    return projectResolveClaudeProjectDirFromSelector(selector, root);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('--claude-project')) throw cliError('INVALID_ARGS', message);
+    throw cliError('NOT_FOUND', message);
   }
-
-  validateClaudeProjectBasename(selector.project);
-  const claudeDir = join(root, selector.project);
-  if (!existsSync(claudeDir)) {
-    throw cliError('NOT_FOUND', `Claude project directory not found: ${claudeDir}`);
-  }
-  return claudeDir;
 }
 
 function sessionProjectSelectorFromArgs(args: {
   project?: string;
   'claude-project'?: string;
 }): SessionProjectSelector {
-  const claudeProject = readRawStringOption('claude-project') ?? (
-    typeof args['claude-project'] === 'string' ? args['claude-project'] : undefined
-  );
-  if (args.project && claudeProject) {
-    throw cliError('INVALID_ARGS', '--project and --claude-project are mutually exclusive');
+  try {
+    return projectSessionProjectSelectorFromArgs(args);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw cliError('INVALID_ARGS', message);
   }
-  if (claudeProject) {
-    return { kind: 'claudeProject', project: claudeProject };
-  }
-  return { kind: 'projectPath', projectPath: args.project || process.cwd() };
 }
 
 /**
@@ -2272,17 +1919,6 @@ export function listSearchTargetsForProject(claudeDir: string, projectRef?: Proj
       filePath: join(claudeDir, f),
       sessionId: f.replace('.jsonl', ''),
       projectRef,
-    }));
-}
-
-export function listSearchTargetsForContext(context: SearchProjectContext): SearchTarget[] {
-  return readdirSync(context.projectRef.claude_dir)
-    .filter(f => f.endsWith('.jsonl'))
-    .map(f => ({
-      filePath: join(context.projectRef.claude_dir, f),
-      sessionId: f.replace('.jsonl', ''),
-      context,
-      projectRef: context.projectRef,
     }));
 }
 

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,35 @@ import { defineCommand, runMain } from 'citty';
 import { homedir } from 'os';
 import { join, basename, dirname, resolve, relative, isAbsolute } from 'path';
 import { readdirSync, existsSync, realpathSync } from 'fs';
+import {
+  aggregateCounterRows,
+  attachCounterTranscriptResults,
+  bucketCounterRows,
+  evidenceTimestamps,
+  parseCounterArgs,
+  parseRegexMatcher,
+  parseSubstringMatcher,
+  SEARCH_EVIDENCE_SNIPPET_CHARS,
+  snippetForMatch,
+  testTextMatcher,
+  toolInputSamplesFromEvidence,
+  type TextMatcher,
+  type SearchEvidence,
+  type SearchEvidenceKind,
+  type SearchMatch,
+  type SearchMeta,
+  type SessionRef,
+  type ToolInputMatch,
+  type SearchBucketMode,
+  type ToolCallScanRecord,
+} from './src/search.ts';
+import {
+  buildSessionSummary,
+  extractSessionIntent,
+  normalizedBlocks,
+  parseSessionText as parseTranscriptSessionText,
+  type SessionSummaryResult,
+} from './src/transcript.ts';
 
 export const VERSION = '0.1.0';
 
@@ -33,10 +62,12 @@ export type SessionEntry = {
   gitBranch?: string;
   version?: string;
   cwd?: string;
+  model?: string;
   message?: {
     role?: string;
     content?: string | ContentBlock[];
     usage?: TokenUsage;
+    model?: string;
   };
   slug?: string;
 };
@@ -71,6 +102,17 @@ export type ListSession = {
   project?: string;
   project_path_guess?: string | null;
   project_role?: SearchProjectRole;
+  session_ref?: SessionRef;
+};
+
+export type ProjectSummary = {
+  project: string;
+  project_path_guess: string | null;
+  project_role: SearchProjectRole;
+  session_count: number;
+  total_lines: number;
+  first_session_at: string | null;
+  last_session_at: string | null;
 };
 
 export type ShapeRow = {
@@ -106,6 +148,10 @@ export type ToolsResult = {
   session_id: string;
   agent_id: string | null;
   tool_calls: ToolCall[];
+};
+
+type ToolCallWithRawInput = ToolCall & {
+  raw_input: Record<string, unknown>;
 };
 
 export type TokenTurn = {
@@ -202,14 +248,6 @@ export type FileMatchResult = {
   logicalPath: string | null;
 };
 
-export type FileMatchEvidence = {
-  rawPath: string;
-  logicalPath: string | null;
-  operation: SearchOperation;
-  turn: number;
-  timestamp: string | null;
-};
-
 export type FileEntry = {
   path: string;
   operations: string[];
@@ -256,38 +294,8 @@ export type SubagentsResult = {
   subagents: SubagentInfo[];
 };
 
-// SearchMatch intentionally omits agent_id — it operates at the session-listing level, not session-scoped.
-export type SearchMatch = {
-  session_id: string;
-  branch: string | null;
-  timestamp: string | null;
-  slug: string | null;
-  project?: string;
-  project_path_guess?: string | null;
-  project_role?: SearchProjectRole;
-  session_ref?: {
-    session_id: string;
-    project: string;
-  };
-  matches: {
-    tools: string[];      // distinct tool names that matched --tool
-    files: string[];      // distinct file paths that matched --file
-    normalized_files?: string[];
-    file_evidence?: FileMatchEvidence[];
-    operations?: SearchOperation[];
-    tool_inputs?: ToolInputMatch[];
-    turns: number[];      // union of all turn numbers where any filter matched
-  };
-};
-
 export type SearchSortMode = 'session-newest' | 'match-earliest' | 'match-newest' | 'project';
-export type SearchAggregateMode = 'none' | 'count-per-session';
-
-export type ToolInputMatch = {
-  tool: string;
-  input_summary: string;
-  turn: number;
-};
+export type SearchAggregateMode = 'none' | 'count-per-session' | 'counters';
 
 export type SearchAggregateResult = {
   session_id: string;
@@ -303,33 +311,38 @@ export type SearchAggregateResult = {
   sample_matches: ToolInputMatch[];
 };
 
-export type SearchMeta = ResponseMeta & {
-  projects_scanned?: number;
-  project?: string;
-  related_projects?: ProjectRef[];
-  included_projects?: PublicProjectRef[];
-  skipped_projects?: PublicProjectRef[];
-  warning?: string;
-};
-
 export type SearchArgs = {
   tool?: string;
   file?: string;
   text?: string;
+  textRegex?: string;
+  textRole?: 'user' | 'assistant' | 'all';
   bash?: string;
+  bashRegex?: string;
   inputMatch?: string;
+  inputRegex?: string;
+  intentMatch?: string;
+  intentRegex?: string;
   branch?: string;
   after?: string;
   before?: string;
   since?: string;
   operation?: SearchOperation;
+  includeSubagents?: boolean;
 };
 
 export type SearchTarget = {
   filePath: string;
   sessionId: string;
+  parentSessionId?: string | null;
+  agentId?: string | null;
   context?: SearchProjectContext;
   projectRef?: ProjectRef;
+};
+
+export type SearchSessionGroup = {
+  parent: SearchTarget;
+  subagents: SearchTarget[];
 };
 
 export type SearchScopeOptions = {
@@ -364,6 +377,13 @@ export type SessionProjectSelector =
 
 export type SearchScanResult = {
   matches: SearchMatch[];
+};
+
+type PreparedSearchArgs = SearchArgs & {
+  textMatcher?: TextMatcher | null;
+  bashMatcher?: TextMatcher | null;
+  inputMatcher?: TextMatcher | null;
+  intentMatcher?: TextMatcher | null;
 };
 
 export type ListMeta = ResponseMeta & {
@@ -1098,6 +1118,41 @@ export async function resolveSession(args: {
   return { sessionId, agentId, entries };
 }
 
+type ResolvedSessionWithText = ResolvedSession & {
+  claudeDir: string;
+  filePath: string;
+  rawText: string;
+  allEntries: SessionEntry[];
+  lineCount: number;
+  metadata: SessionMetadata;
+};
+
+async function resolveSessionWithText(args: {
+  session: string;
+  project?: string;
+  'claude-project'?: string;
+  claudeProjectsRoot?: string;
+}): Promise<ResolvedSessionWithText> {
+  const claudeDir = resolveClaudeProjectDirFromSelector(
+    sessionProjectSelectorFromArgs(args),
+    args.claudeProjectsRoot,
+  );
+  const { filePath, sessionId, agentId } = await resolveSessionFile(claudeDir, args.session);
+  const rawText = await Bun.file(filePath).text();
+  const allEntries = parseSessionText(rawText);
+  return {
+    sessionId,
+    agentId,
+    claudeDir,
+    filePath,
+    rawText,
+    allEntries,
+    entries: userAssistantEntries(allEntries),
+    lineCount: countNonEmptyLines(rawText),
+    metadata: extractSessionMetadata(rawText),
+  };
+}
+
 /** Parse turn range "N" or "N-M". Returns {start, end}. */
 export function parseTurnRange(input: string): { start: number; end: number } {
   const rangeMatch = input.match(/^(\d+)-(\d+)$/);
@@ -1165,6 +1220,18 @@ export function stableJsonStringify(value: unknown): string {
 
 export function toolInputMatches(input: Record<string, unknown>, query: string): boolean {
   return stableJsonStringify(input).toLowerCase().includes(query.toLowerCase());
+}
+
+function toolInputMatchesMatcher(input: Record<string, unknown>, matcher: TextMatcher | null): boolean {
+  return testTextMatcher(matcher, stableJsonStringify(input));
+}
+
+function safeInputSummary(tool: string, input: Record<string, unknown>): string {
+  try {
+    return inputSummary(tool, input);
+  } catch {
+    return stableJsonStringify(input).slice(0, 80);
+  }
 }
 
 /** Determine outcome from a tool_result. */
@@ -1260,6 +1327,7 @@ export type SessionMetadata = {
   timestamp: string | null;
   version: string | null;
   slug: string | null;
+  model: string | null;
 };
 
 type ExtractSessionMetadataOptions = {
@@ -1272,23 +1340,31 @@ export function extractSessionMetadata(text: string, options: ExtractSessionMeta
   let timestamp: string | null = null;
   let version: string | null = null;
   let slug: string | null = null;
+  let model: string | null = null;
 
   let lineStart = 0;
-  for (let j = 0; j < 5 && lineStart <= text.length; j++) {
+  for (let j = 0; j < 50 && lineStart <= text.length; j++) {
     const newlineIndex = text.indexOf('\n', lineStart);
     const lineEnd = newlineIndex === -1 ? text.length : newlineIndex;
     const rawLine = text.slice(lineStart, lineEnd);
     if (rawLine.trim()) {
       try {
         const entry = JSON.parse(rawLine);
-        if (entry.sessionId) {
+        if (model === null) {
+          if (typeof entry.message?.model === 'string' && entry.message.model.trim()) {
+            model = entry.message.model;
+          } else if (typeof entry.model === 'string' && entry.model.trim()) {
+            model = entry.model;
+          }
+        }
+        if (entry.sessionId && branch === null) {
           branch = entry.gitBranch ?? null;
           version = entry.version ?? null;
           timestamp = entry.timestamp ?? null;
-          break;
         }
       } catch { /* skip */ }
     }
+    if (branch !== null && model !== null) break;
     if (newlineIndex === -1) break;
     lineStart = newlineIndex + 1;
   }
@@ -1298,7 +1374,7 @@ export function extractSessionMetadata(text: string, options: ExtractSessionMeta
     if (slugMatch) slug = slugMatch[1] ?? null;
   }
 
-  return { branch, timestamp, version, slug };
+  return { branch, timestamp, version, slug, model };
 }
 
 const isSubagentFile = (f: string) => f.startsWith('agent-') && f.endsWith('.jsonl');
@@ -1408,10 +1484,13 @@ async function listSessionsForContext(
     branch?: string;
     before?: string;
     'include-subagents'?: boolean;
+    'intent-match'?: string;
+    'intent-regex'?: string;
   },
   afterCutoff: string | null,
   minLines: number,
-  includeProjectFields: boolean,
+  includeIdentityFields: boolean,
+  intentMatcher: TextMatcher | null,
 ): Promise<ListSession[]> {
   const files = readdirSync(context.projectRef.claude_dir).filter(f => f.endsWith('.jsonl'));
   const sessions: ListSession[] = [];
@@ -1437,12 +1516,18 @@ async function listSessionsForContext(
         if (args.before) {
           if (!timestamp || timestamp > args.before) return null;
         }
+        if (intentMatcher) {
+          const entries = parseTranscriptSessionText(text);
+          const intents = extractSessionIntent(entries, { slug });
+          if (!intents.some(intent => testTextMatcher(intentMatcher, intent.value))) return null;
+        }
 
         const session: ListSession = { session_id: sessionId, branch, timestamp, version, lines: lineCount, slug };
-        if (includeProjectFields) {
+        if (includeIdentityFields) {
           session.project = context.projectRef.project;
           session.project_path_guess = context.projectRef.project_path_guess;
           session.project_role = context.role;
+          session.session_ref = { session_id: sessionId, project: context.projectRef.project };
         }
         if (args['include-subagents']) {
           try {
@@ -1468,12 +1553,15 @@ async function listSessionsForContext(
 }
 
 const listCommand = defineCommand({
-  meta: { name: 'list', description: 'Index all sessions (metadata only)' },
+  meta: { name: 'list', description: 'Index sessions; scoped lists include associated Claude worktrees by default' },
   args: {
-    project: { type: 'string', description: 'Absolute project path (defaults to CWD)' },
-    'all-projects': { type: 'boolean', description: 'List sessions from all Claude project directories', default: false },
-    'project-glob': { type: 'string', description: 'Filter --all-projects by Claude project identity glob' },
+    project: { type: 'string', description: 'Absolute project path identity anchor (defaults to CWD)' },
+    'main-only': { type: 'boolean', description: 'With --project, list only the main Claude project and skip associated worktree transcript directories', default: false },
+    'all-projects': { type: 'boolean', description: 'List sessions from all Claude project directories; use raw project/session_ref.project for stable follow-up' },
+    'project-glob': { type: 'string', description: 'Filter --all-projects by raw Claude project basename or display-only project_path_guess' },
     branch: { type: 'string', description: 'Filter by git branch' },
+    'intent-match': { type: 'string', description: 'Filter session intent sources by case-insensitive substring' },
+    'intent-regex': { type: 'string', description: 'Filter session intent sources by regex' },
     after: { type: 'string', description: 'Sessions after DATE (ISO 8601)' },
     before: { type: 'string', description: 'Sessions before DATE (ISO 8601)' },
     since: { type: 'string', description: 'Sessions from the last duration (e.g. 1d, 2h, 1w)' },
@@ -1490,6 +1578,12 @@ const listCommand = defineCommand({
       if (args['project-glob'] && !allProjects) {
         throw cliError('INVALID_ARGS', '--project-glob requires --all-projects');
       }
+      if (args['main-only'] && allProjects) {
+        throw cliError('INVALID_ARGS', '--main-only cannot be used with --all-projects');
+      }
+      if (args['intent-match'] && args['intent-regex']) {
+        throw cliError('INVALID_ARGS', '--intent-match and --intent-regex are mutually exclusive');
+      }
 
       if (args.since && args.after) {
         throw cliError('INVALID_ARGS', '--since and --after are mutually exclusive');
@@ -1500,17 +1594,28 @@ const listCommand = defineCommand({
       if (lastN != null && lastN <= 0) {
         throw cliError('INVALID_ARGS', '--last must be a positive integer');
       }
+      const intentMatcher = (() => {
+        try {
+          return args['intent-regex']
+            ? parseRegexMatcher(args['intent-regex'], '--intent-regex')
+            : parseSubstringMatcher(args['intent-match']);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw cliError('INVALID_ARGS', message);
+        }
+      })();
 
       const sessions: ListSession[] = [];
       const selection = selectProjectContexts({
-        mode: allProjects ? 'all-projects' : 'scoped',
+        mode: allProjects ? 'all-projects' : (args['main-only'] ? 'scoped' : 'scoped-with-worktrees'),
         projectPath,
         projectGlob: args['project-glob'],
       });
+      const includeIdentityFields = allProjects || selection.contexts.length > 1;
 
       for (const context of selection.contexts) {
         try {
-          sessions.push(...await listSessionsForContext(context, args, afterCutoff, minLines, allProjects));
+          sessions.push(...await listSessionsForContext(context, args, afterCutoff, minLines, includeIdentityFields, intentMatcher));
         } catch {
           if (!allProjects) throw cliError('NOT_FOUND', `Claude project directory not found: ${context.projectRef.claude_dir}`);
         }
@@ -1528,12 +1633,93 @@ const listCommand = defineCommand({
       const total = sessions.length;
       const returned = lastN != null ? sessions.slice(0, lastN) : sessions;
       const responseMeta: ListMeta = meta(total, returned.length);
-      if (allProjects) {
+      if (allProjects || selection.contexts.length > 1) {
         responseMeta.projects_scanned = selection.contexts.length;
         responseMeta.included_projects = selection.includedProjects;
         responseMeta.skipped_projects = selection.skippedProjects;
       }
       output(success(returned, responseMeta));
+    } catch (err: unknown) {
+      handleCommandError(err);
+    }
+  },
+});
+
+async function summarizeProjectContext(context: SearchProjectContext): Promise<ProjectSummary> {
+  const summary: ProjectSummary = {
+    project: context.projectRef.project,
+    project_path_guess: context.projectRef.project_path_guess,
+    project_role: context.role,
+    session_count: 0,
+    total_lines: 0,
+    first_session_at: null,
+    last_session_at: null,
+  };
+  if (!existsSync(context.projectRef.claude_dir)) {
+    throw new Error(`Claude project directory not found: ${context.projectRef.claude_dir}`);
+  }
+
+  const files = readdirSync(context.projectRef.claude_dir).filter(f => f.endsWith('.jsonl')).sort((a, b) => a.localeCompare(b));
+  for (const file of files) {
+    try {
+      const text = await Bun.file(join(context.projectRef.claude_dir, file)).text();
+      const lines = countNonEmptyLines(text);
+      const { timestamp } = extractSessionMetadata(text, { includeSlug: false });
+      summary.session_count++;
+      summary.total_lines += lines;
+      if (timestamp) {
+        if (!summary.first_session_at || timestamp < summary.first_session_at) summary.first_session_at = timestamp;
+        if (!summary.last_session_at || timestamp > summary.last_session_at) summary.last_session_at = timestamp;
+      }
+    } catch {
+      // Project summaries are metadata indexes; skip unreadable transcript files.
+    }
+  }
+
+  return summary;
+}
+
+// ============================================================================
+// Projects Command
+// ============================================================================
+
+const projectsCommand = defineCommand({
+  meta: { name: 'projects', description: 'Summarize Claude project directories and raw project handles' },
+  args: {
+    glob: { type: 'string', description: 'Filter by raw Claude project basename or display-only project_path_guess' },
+    project: { type: 'string', description: 'Absolute project path; include its main and associated worktree projects' },
+  },
+  async run({ args }) {
+    try {
+      const selection = selectProjectContexts({
+        mode: args.project ? 'scoped-with-worktrees' : 'all-projects',
+        projectPath: args.project,
+        projectGlob: args.project ? undefined : args.glob,
+      });
+      let contexts = selection.contexts;
+      if (args.project && args.glob) {
+        contexts = contexts.filter(context => projectMatchesGlob(context.projectRef, args.glob!));
+      }
+
+      const summaries: ProjectSummary[] = [];
+      for (const context of contexts) {
+        try {
+          summaries.push(await summarizeProjectContext(context));
+        } catch {
+          if (args.project) throw cliError('NOT_FOUND', `Claude project directory not found: ${context.projectRef.claude_dir}`);
+        }
+      }
+      summaries.sort((a, b) => a.project.localeCompare(b.project));
+
+      const responseMeta: ListMeta = meta(summaries.length, summaries.length);
+      responseMeta.projects_scanned = contexts.length;
+      responseMeta.included_projects = contexts.map(context => ({
+        project: context.projectRef.project,
+        project_path_guess: context.projectRef.project_path_guess,
+        project_role: context.role,
+      }));
+      responseMeta.skipped_projects = args.project ? [] : selection.skippedProjects;
+      output(success(summaries, responseMeta));
     } catch (err: unknown) {
       handleCommandError(err);
     }
@@ -1704,21 +1890,74 @@ const shapeCommand = defineCommand({
 });
 
 // ============================================================================
+// Summary Command
+// ============================================================================
+
+const summaryCommand = defineCommand({
+  meta: { name: 'summary', description: 'One-call triage summary for a session; use session_ref.project as --claude-project for stable follow-up' },
+  args: {
+    session: { type: 'positional', description: 'Session ID (UUID, prefix, slug, or session:agent-id)', required: true },
+    project: { type: 'string', description: 'Absolute project path (defaults to CWD)' },
+    'claude-project': { type: 'string', description: 'Raw Claude project directory basename' },
+  },
+  async run({ args }) {
+    try {
+      const resolved = await resolveSessionWithText(args);
+      const subagents = resolved.agentId === null
+        ? await listSubagents(resolved.claudeDir, resolved.sessionId)
+        : [];
+      const result: SessionSummaryResult = buildSessionSummary({
+        sessionId: resolved.sessionId,
+        agentId: resolved.agentId,
+        entries: resolved.entries,
+        metadata: resolved.metadata,
+        lineCount: resolved.lineCount,
+        subagents,
+      });
+      output(success(result, meta(1, 1)));
+    } catch (err: unknown) {
+      handleCommandError(err);
+    }
+  },
+});
+
+// ============================================================================
 // Tools Command
 // ============================================================================
 
 const toolsCommand = defineCommand({
-  meta: { name: 'tools', description: 'Tool call log with condensed input summaries' },
+  meta: { name: 'tools', description: 'Tool call log with outcomes; --input-match searches raw structured inputs beyond input_summary' },
   args: {
     session: { type: 'positional', description: 'Session ID (UUID, prefix, or slug)', required: true },
     project: { type: 'string', description: 'Absolute project path (defaults to CWD)' },
     'claude-project': { type: 'string', description: 'Raw Claude project directory basename' },
     name: { type: 'string', description: 'Filter by tool name' },
+    'name-match': { type: 'string', description: 'Filter tool names by case-insensitive substring' },
+    'input-match': { type: 'string', description: 'Filter by raw structured tool input substring' },
+    'input-regex': { type: 'string', description: 'Filter by raw structured tool input regex' },
     failed: { type: 'boolean', description: 'Show only failed/empty outcomes', default: false },
     turn: { type: 'string', description: 'Filter by turn N or N-M' },
   },
   async run({ args }) {
     try {
+      if (args.name && args['name-match']) {
+        throw cliError('INVALID_ARGS', '--name and --name-match are mutually exclusive');
+      }
+      if (args['input-match'] && args['input-regex']) {
+        throw cliError('INVALID_ARGS', '--input-match and --input-regex are mutually exclusive');
+      }
+      let inputMatcher: TextMatcher | null = null;
+      if (args['input-regex']) {
+        try {
+          inputMatcher = parseRegexMatcher(args['input-regex'], '--input-regex');
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw cliError('INVALID_ARGS', message);
+        }
+      } else {
+        inputMatcher = parseSubstringMatcher(args['input-match']);
+      }
+      const nameMatcher = parseSubstringMatcher(args['name-match']);
       const { sessionId, agentId, entries } = await resolveSession(args);
 
       const turnRange = args.turn ? parseTurnRange(args.turn) : null;
@@ -1726,12 +1965,13 @@ const toolsCommand = defineCommand({
       const resultLookup = buildResultLookup(entries);
 
       // Pass 2: Extract tool calls
-      let calls: ToolCall[] = [];
+      let calls: ToolCallWithRawInput[] = [];
       let turnNum = 0;
       for (const entry of entries) {
         turnNum++;
         if (entry.type === 'assistant' && Array.isArray(entry.message?.content)) {
           for (const block of entry.message!.content as ContentBlock[]) {
+            const rawInput = block.input ?? {};
             if (block.type === 'tool_use' && block.name) {
               const resultInfo = resultLookup.get(block.id ?? '') ?? null;
               let durationMs: number | null = null;
@@ -1742,9 +1982,10 @@ const toolsCommand = defineCommand({
               calls.push({
                 turn: turnNum,
                 tool: block.name,
-                input_summary: inputSummary(block.name, block.input ?? {}),
+                input_summary: inputSummary(block.name, rawInput),
                 outcome: determineOutcome(resultInfo),
                 duration_ms: durationMs,
+                raw_input: rawInput,
               });
             }
           }
@@ -1753,11 +1994,14 @@ const toolsCommand = defineCommand({
 
       // Apply filters
       if (args.name) calls = calls.filter(c => c.tool === args.name);
+      if (nameMatcher) calls = calls.filter(c => testTextMatcher(nameMatcher, c.tool));
+      if (inputMatcher) calls = calls.filter(c => toolInputMatchesMatcher(c.raw_input, inputMatcher));
       if (args.failed) calls = calls.filter(c => c.outcome === 'empty' || c.outcome.startsWith('error:'));
       if (turnRange) calls = calls.filter(c => c.turn >= turnRange.start && c.turn <= turnRange.end);
 
       const total = calls.length;
-      const result: ToolsResult = { session_id: sessionId, agent_id: agentId, tool_calls: calls };
+      const publicCalls: ToolCall[] = calls.map(({ raw_input: _rawInput, ...call }) => call);
+      const result: ToolsResult = { session_id: sessionId, agent_id: agentId, tool_calls: publicCalls };
       output(success(result, meta(total, total)));
     } catch (err: unknown) {
       handleCommandError(err);
@@ -1866,13 +2110,19 @@ const messagesCommand = defineCommand({
     type: { type: 'string', description: 'Filter by content block type' },
     turn: { type: 'string', description: 'Filter by turn N or N-M' },
     'max-content': { type: 'string', description: 'Truncate content to N chars (default: 200)' },
+    'max-tool-result': { type: 'string', description: 'Truncate tool_result content to N chars (default: 200)' },
   },
   async run({ args }) {
     try {
       const { sessionId, agentId, entries } = await resolveSession(args);
 
-      const maxContent = parseIntArg(args['max-content'], '--max-content') ?? 200;
       const turnRange = args.turn ? parseTurnRange(args.turn) : null;
+      const maxContent = parseIntArg(args['max-content'], '--max-content');
+      const maxToolResult = parseIntArg(args['max-tool-result'], '--max-tool-result');
+      const singleTurn = turnRange != null && turnRange.start === turnRange.end;
+      const textMax = maxContent ?? (singleTurn ? null : 200);
+      const thinkingMax = maxContent ?? (singleTurn ? null : 200);
+      const toolResultMax = maxToolResult ?? maxContent ?? 200;
       if (args.role && args.role !== 'user' && args.role !== 'assistant') {
         throw cliError('INVALID_ARGS', "--role must be 'user' or 'assistant'");
       }
@@ -1910,9 +2160,9 @@ const messagesCommand = defineCommand({
         const processed = blocks.map(block => {
           switch (block.type) {
             case 'text':
-              return { type: 'text', text: truncateContent(block.text ?? '', maxContent) };
+              return { type: 'text', text: textMax == null ? block.text ?? '' : truncateContent(block.text ?? '', textMax) };
             case 'thinking':
-              return { type: 'thinking', text: truncateContent(block.thinking ?? '', maxContent) };
+              return { type: 'thinking', text: thinkingMax == null ? block.thinking ?? '' : truncateContent(block.thinking ?? '', thinkingMax) };
             case 'tool_use':
               return { type: 'tool_use', name: block.name, id: block.id };
             case 'tool_result': {
@@ -1921,7 +2171,7 @@ const messagesCommand = defineCommand({
                 type: 'tool_result',
                 tool_use_id: block.tool_use_id,
                 is_error: block.is_error ?? false,
-                content: truncateContent(contentText, maxContent),
+                content: truncateContent(contentText, toolResultMax),
               };
             }
             case 'image':
@@ -1971,7 +2221,7 @@ const sliceCommand = defineCommand({
         if (turnNum < turnRange.start) continue;
         if (turnNum > turnRange.end) break;
 
-        if (maxContent != null && maxContent > 0) {
+        if (maxContent != null) {
           // Deep clone and truncate content blocks
           const cloned = JSON.parse(JSON.stringify(entry)) as SessionEntry;
           truncateEntryContent(cloned, maxContent);
@@ -2036,6 +2286,30 @@ export function listSearchTargetsForContext(context: SearchProjectContext): Sear
     }));
 }
 
+function listSubagentTargetsForParent(parent: SearchTarget): SearchTarget[] {
+  const claudeDir = parent.context?.projectRef.claude_dir ?? parent.projectRef?.claude_dir ?? dirname(parent.filePath);
+  const subagentDir = join(claudeDir, parent.sessionId, 'subagents');
+  if (!existsSync(subagentDir)) return [];
+  return readdirSync(subagentDir)
+    .filter(isSubagentFile)
+    .sort()
+    .map(file => ({
+      filePath: join(subagentDir, file),
+      sessionId: parent.sessionId,
+      parentSessionId: parent.sessionId,
+      agentId: file.slice('agent-'.length, -'.jsonl'.length),
+      context: parent.context,
+      projectRef: parent.projectRef,
+    }));
+}
+
+export function listSearchSessionGroupsForContext(context: SearchProjectContext, includeSubagents: boolean): SearchSessionGroup[] {
+  return listSearchTargetsForContext(context).map(parent => ({
+    parent,
+    subagents: includeSubagents ? listSubagentTargetsForParent(parent) : [],
+  }));
+}
+
 export async function mapConcurrent<T, R>(
   items: T[],
   concurrency: number,
@@ -2057,24 +2331,53 @@ export async function mapConcurrent<T, R>(
   return results;
 }
 
-type SearchTargetResult = {
-  match: SearchMatch | null;
+type TranscriptScan = {
+  target: SearchTarget;
+  metadata: ReturnType<typeof extractSessionMetadata>;
+  evidence: SearchEvidence[];
+  allToolCalls: ToolCallScanRecord[];
+  tools: string[];
+  files: string[];
+  normalizedFiles: string[];
+  operations: SearchOperation[];
+  turns: number[];
+  hits: {
+    tool: boolean;
+    file: boolean;
+    text: boolean;
+    bash: boolean;
+    input: boolean;
+    intent: boolean;
+  };
 };
 
-export async function scanSearchTarget(target: SearchTarget, args: SearchArgs, afterCutoff: string | null): Promise<SearchTargetResult> {
+function sessionRefForSearchTarget(target: SearchTarget): SessionRef {
+  const projectRef = target.context?.projectRef ?? target.projectRef;
+  const ref: SessionRef = {
+    session_id: target.sessionId,
+    project: projectRef?.project ?? basename(dirname(target.filePath)),
+  };
+  if (target.agentId) ref.agent_id = target.agentId;
+  return ref;
+}
+
+function addEvidenceProvenance(evidence: SearchEvidence, target: SearchTarget): SearchEvidence {
+  if (target.agentId) {
+    evidence.agent_id = target.agentId;
+    evidence.parent_session_id = target.parentSessionId ?? target.sessionId;
+    evidence.is_subagent = true;
+  }
+  return evidence;
+}
+
+function searchKindHit(evidence: SearchEvidence[], kind: SearchEvidenceKind): boolean {
+  return evidence.some(item => item.kind === kind);
+}
+
+async function scanSearchTranscript(target: SearchTarget, args: PreparedSearchArgs): Promise<TranscriptScan | null> {
   try {
     const text = await Bun.file(target.filePath).text();
-
-    const { branch, timestamp, slug } = extractSessionMetadata(text);
-
-    if (args.branch && branch !== args.branch) return { match: null };
-    if (afterCutoff) {
-      if (!timestamp || timestamp < afterCutoff) return { match: null };
-    }
-    if (args.before) {
-      if (!timestamp || timestamp > args.before) return { match: null };
-    }
-
+    const metadata = extractSessionMetadata(text);
     const entries = parseSessionText(text);
     const uaEntries = userAssistantEntries(entries);
     const sessionContext = target.context ? buildSearchSessionContext(target.context, entries) : null;
@@ -2082,24 +2385,60 @@ export async function scanSearchTarget(target: SearchTarget, args: SearchArgs, a
     const matchedTools = new Set<string>();
     const matchedFiles = new Set<string>();
     const matchedNormalizedFiles = new Set<string>();
-    const matchedFileEvidence: FileMatchEvidence[] = [];
+    const matchedEvidence: SearchEvidence[] = [];
+    const allToolCalls: ToolCallScanRecord[] = [];
     const matchedOperations = new Set<SearchOperation>();
-    const matchedToolInputs: ToolInputMatch[] = [];
     const matchedTurns = new Set<number>();
 
     const toolQuery = args.tool?.toLowerCase();
     const fileQuery = args.file && sessionContext ? normalizeFileQuery(args.file, sessionContext) : null;
     const rawFileQuery = args.file?.toLowerCase();
-    const textQuery = args.text?.toLowerCase();
-    const bashQuery = args.bash?.toLowerCase();
-    const inputQuery = args.inputMatch?.toLowerCase();
     const operationQuery = args.operation;
+    const textRole = args.textRole ?? 'all';
 
-    let toolHit = !toolQuery;
+    for (const intent of extractSessionIntent(entries, metadata)) {
+      if (!args.intentMatcher || !testTextMatcher(args.intentMatcher, intent.value)) continue;
+      matchedEvidence.push(addEvidenceProvenance({
+        kind: 'intent',
+        turn: intent.source === 'slug' ? 0 : 1,
+        block_index: null,
+        timestamp: metadata.timestamp,
+        snippet: snippetForMatch(intent.value, args.intentMatcher, SEARCH_EVIDENCE_SNIPPET_CHARS),
+        intent_source: intent.source,
+      }, target));
+    }
+
+    for (const normalized of normalizedBlocks(entries)) {
+      if (args.textMatcher && (textRole === 'all' || normalized.role === textRole)) {
+        if (normalized.block.type === 'text' && typeof normalized.block.text === 'string' && testTextMatcher(args.textMatcher, normalized.block.text)) {
+          matchedEvidence.push(addEvidenceProvenance({
+            kind: 'text',
+            turn: normalized.turn,
+            block_index: normalized.block_index,
+            timestamp: normalized.timestamp,
+            role: normalized.role,
+            snippet: snippetForMatch(normalized.block.text, args.textMatcher, SEARCH_EVIDENCE_SNIPPET_CHARS),
+          }, target));
+          matchedTurns.add(normalized.turn);
+        }
+        if (normalized.block.type === 'thinking' && typeof normalized.block.thinking === 'string' && testTextMatcher(args.textMatcher, normalized.block.thinking)) {
+          matchedEvidence.push(addEvidenceProvenance({
+            kind: 'thinking',
+            turn: normalized.turn,
+            block_index: normalized.block_index,
+            timestamp: normalized.timestamp,
+            role: normalized.role,
+            snippet: snippetForMatch(normalized.block.thinking, args.textMatcher, SEARCH_EVIDENCE_SNIPPET_CHARS),
+          }, target));
+          matchedTurns.add(normalized.turn);
+        }
+      }
+    }
+
+    let toolHit = !args.tool;
     let fileHit = !args.file;
-    let textHit = !textQuery;
-    let bashHit = !bashQuery;
-    let inputHit = !inputQuery;
+    let bashHit = !args.bashMatcher;
+    let inputHit = !args.inputMatcher;
 
     for (let ei = 0; ei < uaEntries.length; ei++) {
       const entry = uaEntries[ei]!;
@@ -2107,7 +2446,23 @@ export async function scanSearchTarget(target: SearchTarget, args: SearchArgs, a
       const content = entry.message?.content;
       if (!Array.isArray(content)) continue;
 
-      for (const block of content as ContentBlock[]) {
+      for (let blockIndex = 0; blockIndex < content.length; blockIndex++) {
+        const block = (content as ContentBlock[])[blockIndex]!;
+        if (block.type === 'tool_use' && block.name) {
+          const rawInput = block.input ?? {};
+          allToolCalls.push({
+            turn: turnNum,
+            block_index: blockIndex,
+            timestamp: entry.timestamp ?? null,
+            tool: block.name,
+            input_summary: safeInputSummary(block.name, rawInput),
+            rawInput,
+            agentId: target.agentId ?? null,
+            parentSessionId: target.parentSessionId ?? null,
+            isSubagent: Boolean(target.agentId),
+          });
+        }
+
         if (toolQuery && block.type === 'tool_use' && block.name) {
           if (block.name.toLowerCase().includes(toolQuery)) {
             matchedTools.add(block.name);
@@ -2116,20 +2471,24 @@ export async function scanSearchTarget(target: SearchTarget, args: SearchArgs, a
           }
         }
 
-        if ((toolQuery || inputQuery) && block.type === 'tool_use' && block.name) {
+        if ((args.tool || args.inputMatcher) && block.type === 'tool_use' && block.name) {
           const input = block.input ?? {};
           const nameMatches = !toolQuery || block.name.toLowerCase().includes(toolQuery);
-          const inputMatches = !inputQuery || toolInputMatches(input, inputQuery);
+          const inputMatches = toolInputMatchesMatcher(input, args.inputMatcher ?? null);
           if (nameMatches && inputMatches) {
-            matchedToolInputs.push({
-              tool: block.name,
-              input_summary: inputSummary(block.name, input),
+            matchedEvidence.push(addEvidenceProvenance({
+              kind: 'tool_input',
               turn: turnNum,
-            });
+              block_index: blockIndex,
+              timestamp: entry.timestamp ?? null,
+              tool: block.name,
+              input_summary: safeInputSummary(block.name, input),
+              snippet: args.inputMatcher ? snippetForMatch(stableJsonStringify(input), args.inputMatcher, SEARCH_EVIDENCE_SNIPPET_CHARS) : undefined,
+            }, target));
             matchedTools.add(block.name);
             matchedTurns.add(turnNum);
             if (toolQuery) toolHit = true;
-            if (inputQuery) inputHit = true;
+            if (args.inputMatcher) inputHit = true;
           }
         }
 
@@ -2149,13 +2508,15 @@ export async function scanSearchTarget(target: SearchTarget, args: SearchArgs, a
             if (!operationQuery || fileInfo.operation === operationQuery) {
               matchedFiles.add(fileInfo.path);
               if (fileMatch.logicalPath) matchedNormalizedFiles.add(fileMatch.logicalPath);
-              matchedFileEvidence.push({
+              matchedEvidence.push(addEvidenceProvenance({
+                kind: 'file',
                 rawPath: fileInfo.path,
                 logicalPath: fileMatch.logicalPath,
                 operation: fileInfo.operation,
                 turn: turnNum,
+                block_index: blockIndex,
                 timestamp: entry.timestamp ?? null,
-              });
+              }, target));
               matchedOperations.add(fileInfo.operation);
               matchedTurns.add(turnNum);
               fileHit = true;
@@ -2163,20 +2524,17 @@ export async function scanSearchTarget(target: SearchTarget, args: SearchArgs, a
           }
         }
 
-        if (textQuery && entry.type === 'assistant') {
-          if (block.type === 'text' && block.text && block.text.toLowerCase().includes(textQuery)) {
-            matchedTurns.add(turnNum);
-            textHit = true;
-          }
-          if (block.type === 'thinking' && block.thinking && block.thinking.toLowerCase().includes(textQuery)) {
-            matchedTurns.add(turnNum);
-            textHit = true;
-          }
-        }
-
-        if (bashQuery && block.type === 'tool_use' && block.name === 'Bash') {
+        if (args.bashMatcher && block.type === 'tool_use' && block.name === 'Bash') {
           const command = (block.input as Record<string, any>)?.command;
-          if (typeof command === 'string' && command.toLowerCase().includes(bashQuery)) {
+          if (typeof command === 'string' && testTextMatcher(args.bashMatcher, command)) {
+            matchedEvidence.push(addEvidenceProvenance({
+              kind: 'bash',
+              turn: turnNum,
+              block_index: blockIndex,
+              timestamp: entry.timestamp ?? null,
+              tool: 'Bash',
+              snippet: snippetForMatch(command, args.bashMatcher, SEARCH_EVIDENCE_SNIPPET_CHARS),
+            }, target));
             matchedTurns.add(turnNum);
             bashHit = true;
           }
@@ -2184,17 +2542,80 @@ export async function scanSearchTarget(target: SearchTarget, args: SearchArgs, a
       }
     }
 
-    if (!toolHit || !fileHit || !textHit || !bashHit || !inputHit) return { match: null };
+    return {
+      target,
+      metadata,
+      evidence: matchedEvidence,
+      allToolCalls,
+      tools: Array.from(matchedTools),
+      files: Array.from(matchedFiles),
+      normalizedFiles: Array.from(matchedNormalizedFiles),
+      operations: Array.from(matchedOperations),
+      turns: Array.from(matchedTurns),
+      hits: {
+        tool: toolHit,
+        file: fileHit,
+        text: !args.textMatcher || searchKindHit(matchedEvidence, 'text') || searchKindHit(matchedEvidence, 'thinking'),
+        bash: bashHit,
+        input: inputHit,
+        intent: !args.intentMatcher || searchKindHit(matchedEvidence, 'intent'),
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function scanSearchGroup(group: SearchSessionGroup, args: PreparedSearchArgs, afterCutoff: string | null): Promise<SearchMatch | null> {
+  const parentScan = await scanSearchTranscript(group.parent, args);
+  if (!parentScan) return null;
+
+  const { branch, timestamp, slug, model } = parentScan.metadata;
+
+  if (args.branch && branch !== args.branch) return null;
+  if (afterCutoff) {
+    if (!timestamp || timestamp < afterCutoff) return null;
+  }
+  if (args.before) {
+    if (!timestamp || timestamp > args.before) return null;
+  }
+
+  const scans = [parentScan];
+  for (const subagent of group.subagents) {
+    const scan = await scanSearchTranscript(subagent, args);
+    if (scan) scans.push(scan);
+  }
+
+  const hit = (name: keyof TranscriptScan['hits']) => scans.some(scan => scan.hits[name]);
+  if (!hit('tool') || !hit('file') || !hit('text') || !hit('bash') || !hit('input') || !hit('intent')) return null;
+
+  const matchedTools = new Set<string>();
+  const matchedFiles = new Set<string>();
+  const matchedNormalizedFiles = new Set<string>();
+  const matchedOperations = new Set<SearchOperation>();
+  const matchedTurns = new Set<number>();
+  const matchedEvidence: SearchEvidence[] = [];
+  for (const scan of scans) {
+    scan.tools.forEach(item => matchedTools.add(item));
+    scan.files.forEach(item => matchedFiles.add(item));
+    scan.normalizedFiles.forEach(item => matchedNormalizedFiles.add(item));
+    scan.operations.forEach(item => matchedOperations.add(item));
+    scan.turns.forEach(item => matchedTurns.add(item));
+    matchedEvidence.push(...scan.evidence);
+  }
 
     const match: SearchMatch = {
-      session_id: target.sessionId,
+      session_id: group.parent.sessionId,
       branch,
       timestamp,
       slug,
+      model,
+      session_ref: sessionRefForSearchTarget(group.parent),
       matches: {
         tools: Array.from(matchedTools),
         files: Array.from(matchedFiles),
         turns: Array.from(matchedTurns).sort((a, b) => a - b),
+        evidence: matchedEvidence,
       },
     };
 
@@ -2204,42 +2625,56 @@ export async function scanSearchTarget(target: SearchTarget, args: SearchArgs, a
     if (matchedNormalizedFiles.size > 0) {
       match.matches.normalized_files = Array.from(matchedNormalizedFiles);
     }
-    if (matchedFileEvidence.length > 0) {
-      match.matches.file_evidence = matchedFileEvidence;
-    }
-    if (matchedToolInputs.length > 0) {
-      match.matches.tool_inputs = matchedToolInputs;
-    }
-    const projectRef = target.context?.projectRef ?? target.projectRef;
-    const exposeProjectRef = target.context ? target.context.role !== 'main' : Boolean(target.projectRef);
+    const projectRef = group.parent.context?.projectRef ?? group.parent.projectRef;
+    const exposeProjectRef = group.parent.context ? group.parent.context.role !== 'main' : Boolean(group.parent.projectRef);
     if (projectRef && exposeProjectRef) {
       match.project = projectRef.project;
       match.project_path_guess = projectRef.project_path_guess;
-      if (target.context) {
-        match.project_role = target.context.role;
+      if (group.parent.context) {
+        match.project_role = group.parent.context.role;
       }
-      match.session_ref = {
-        session_id: target.sessionId,
-        project: projectRef.project,
-      };
     }
 
-    return { match };
-  } catch {
-    return { match: null };
-  }
+    attachCounterTranscriptResults(match, scans.map(scan => ({
+      target: {
+        filePath: scan.target.filePath,
+        sessionId: scan.target.sessionId,
+        parentSessionId: scan.target.parentSessionId ?? null,
+        agentId: scan.target.agentId ?? null,
+        context: scan.target.context,
+        projectRef: scan.target.projectRef,
+      },
+      metadata: scan.metadata,
+      allToolCalls: scan.allToolCalls,
+    })));
+
+    return match;
 }
 
-export async function scanSearchTargets(targets: SearchTarget[], args: SearchArgs, afterCutoff: string | null): Promise<SearchScanResult> {
+export async function scanSearchTarget(target: SearchTarget, args: SearchArgs, afterCutoff: string | null): Promise<{ match: SearchMatch | null }> {
+  const preparedArgs: PreparedSearchArgs = {
+    ...args,
+    textMatcher: parseSubstringMatcher(args.text),
+    bashMatcher: parseSubstringMatcher(args.bash),
+    inputMatcher: parseSubstringMatcher(args.inputMatch),
+    intentMatcher: parseSubstringMatcher(args.intentMatch),
+    includeSubagents: false,
+  };
+  return {
+    match: await scanSearchGroup({ parent: target, subagents: [] }, preparedArgs, afterCutoff),
+  };
+}
+
+export async function scanSearchGroups(groups: SearchSessionGroup[], args: PreparedSearchArgs, afterCutoff: string | null): Promise<SearchScanResult> {
   const matches: SearchMatch[] = [];
 
-  const targetResults = await mapConcurrent(
-    targets,
+  const groupResults = await mapConcurrent(
+    groups,
     SEARCH_SCAN_CONCURRENCY,
-    target => scanSearchTarget(target, args, afterCutoff),
+    group => scanSearchGroup(group, args, afterCutoff),
   );
-  for (const result of targetResults) {
-    if (result.match) matches.push(result.match);
+  for (const match of groupResults) {
+    if (match) matches.push(match);
   }
 
   return { matches };
@@ -2247,18 +2682,18 @@ export async function scanSearchTargets(targets: SearchTarget[], args: SearchArg
 
 export async function scanProjectContexts(
   contexts: SearchProjectContext[],
-  args: SearchArgs,
+  args: PreparedSearchArgs,
   afterCutoff: string | null,
 ): Promise<SearchScanResult> {
-  const targets: SearchTarget[] = [];
+  const groups: SearchSessionGroup[] = [];
   for (const context of contexts) {
     try {
-      targets.push(...listSearchTargetsForContext(context));
+      groups.push(...listSearchSessionGroupsForContext(context, args.includeSubagents ?? true));
     } catch {
       // Preserve search's tolerant handling of unreadable Claude project directories.
     }
   }
-  return scanSearchTargets(targets, args, afterCutoff);
+  return scanSearchGroups(groups, args, afterCutoff);
 }
 
 function compareNullableTimestamp(a: string | null | undefined, b: string | null | undefined, direction: 'asc' | 'desc'): number {
@@ -2268,15 +2703,8 @@ function compareNullableTimestamp(a: string | null | undefined, b: string | null
   return direction === 'asc' ? a.localeCompare(b) : b.localeCompare(a);
 }
 
-function sortedEvidenceTimestamps(match: SearchMatch): string[] {
-  return (match.matches.file_evidence ?? [])
-    .map(evidence => evidence.timestamp)
-    .filter((timestamp): timestamp is string => Boolean(timestamp))
-    .sort();
-}
-
 function matchTimestamp(match: SearchMatch, mode: 'earliest' | 'newest'): string | null {
-  const timestamps = sortedEvidenceTimestamps(match);
+  const timestamps = evidenceTimestamps(match, 'file');
   if (timestamps.length === 0) return match.timestamp;
   return mode === 'earliest' ? timestamps[0]! : timestamps[timestamps.length - 1]!;
 }
@@ -2316,9 +2744,9 @@ export function aggregateSearchMatches(matches: SearchMatch[], mode: SearchAggre
       timestamp: match.timestamp,
       slug: match.slug,
       counts: {
-        tool_inputs: match.matches.tool_inputs?.length ?? 0,
+        tool_inputs: match.matches.evidence.filter(evidence => evidence.kind === 'tool_input').length,
       },
-      sample_matches: (match.matches.tool_inputs ?? []).slice(0, 5),
+      sample_matches: toolInputSamplesFromEvidence(match.matches.evidence),
     };
     if (match.project !== undefined) result.project = match.project;
     if (match.project_path_guess !== undefined) result.project_path_guess = match.project_path_guess;
@@ -2332,31 +2760,61 @@ export function aggregateSearchMatches(matches: SearchMatch[], mode: SearchAggre
 // ============================================================================
 
 const searchCommand = defineCommand({
-  meta: { name: 'search', description: 'Find sessions matching structured queries' },
+  meta: { name: 'search', description: 'Find sessions with unified evidence; scoped search includes worktrees and subagents by default' },
   args: {
     project: { type: 'string', description: 'Absolute project path (defaults to CWD)' },
     'all-projects': { type: 'boolean', description: 'Search all Claude project directories', default: false },
     'project-glob': { type: 'string', description: 'Filter --all-projects by Claude project identity glob' },
     tool: { type: 'string', description: 'Sessions using a specific tool (case-insensitive substring)' },
     'input-match': { type: 'string', description: 'Sessions with raw structured tool input containing a case-insensitive substring' },
+    'input-regex': { type: 'string', description: 'Sessions with raw structured tool input matching a regex' },
     file: { type: 'string', description: 'Sessions that touched a file (substring match on path)' },
-    text: { type: 'string', description: 'Search in assistant text and thinking content (case-insensitive substring)' },
+    text: { type: 'string', description: 'Search in user/assistant text and thinking content (case-insensitive substring)' },
+    'text-regex': { type: 'string', description: 'Search in user/assistant text and thinking content with a regex' },
+    'text-role': { type: 'string', description: 'Restrict text search to user, assistant, or all' },
+    'intent-match': { type: 'string', description: 'Search session intent sources by substring' },
+    'intent-regex': { type: 'string', description: 'Search session intent sources by regex' },
     bash: { type: 'string', description: 'Search in Bash command inputs (case-insensitive substring)' },
+    'bash-regex': { type: 'string', description: 'Search in Bash command inputs with a regex' },
+    subagents: { type: 'boolean', description: 'Include one-level subagent transcripts in search groups by default; use --no-subagents to disable', default: true },
     branch: { type: 'string', description: 'Filter by git branch' },
     after: { type: 'string', description: 'Sessions after DATE (ISO 8601)' },
     before: { type: 'string', description: 'Sessions before DATE (ISO 8601)' },
     since: { type: 'string', description: 'Sessions from the last duration (e.g. 1d, 2h, 1w)' },
-    operation: { type: 'string', description: 'With --file, filter by operation: read/edit/write/grep/glob' },
+    operation: { type: 'string', description: 'With --file, bind operation to the same matching file access: read/edit/write/grep/glob' },
     origin: { type: 'boolean', description: 'With --file, return earliest matching write evidence', default: false },
     sort: { type: 'string', description: 'Sort mode: session-newest, match-earliest, match-newest, project' },
-    aggregate: { type: 'string', description: 'Aggregate mode: count-per-session' },
+    aggregate: { type: 'string', description: 'Aggregate mode: count-per-session, counters' },
+    counter: { type: 'string', description: 'Named raw-input counter as NAME=substring' },
+    'counter-regex': { type: 'string', description: 'Named raw-input counter as NAME=regex' },
+    bucket: { type: 'string', description: 'Bucket counter aggregates by: day, week' },
+    'per-subagent': { type: 'boolean', description: 'Emit transcript-level counter rows instead of parent session rollups', default: false },
     last: { type: 'string', description: 'Return only the last N matches' },
   },
   async run({ args }) {
     try {
+      const rawArgs = args as Record<string, unknown>;
+      const hasCounters = Boolean(rawArgs.counter) || Boolean(rawArgs['counter-regex']);
       // Validate at least one search filter is provided
-      if (!args.tool && !args['input-match'] && !args.file && !args.text && !args.bash) {
-        throw cliError('INVALID_ARGS', 'At least one search filter is required (--tool, --input-match, --file, --text, or --bash)');
+      if (!args.tool && !args['input-match'] && !args['input-regex'] && !args.file && !args.text && !args['text-regex'] && !args.bash && !args['bash-regex'] && !args['intent-match'] && !args['intent-regex'] && !hasCounters) {
+        throw cliError('INVALID_ARGS', 'At least one search filter is required (--tool, --input-match, --input-regex, --file, --text, --text-regex, --intent-match, --intent-regex, --bash, --bash-regex, --counter, or --counter-regex)');
+      }
+
+      if (args['input-match'] && args['input-regex']) {
+        throw cliError('INVALID_ARGS', '--input-match and --input-regex are mutually exclusive');
+      }
+      if (args.text && args['text-regex']) {
+        throw cliError('INVALID_ARGS', '--text and --text-regex are mutually exclusive');
+      }
+      if (args['intent-match'] && args['intent-regex']) {
+        throw cliError('INVALID_ARGS', '--intent-match and --intent-regex are mutually exclusive');
+      }
+      if (args.bash && args['bash-regex']) {
+        throw cliError('INVALID_ARGS', '--bash and --bash-regex are mutually exclusive');
+      }
+      const textRole = (args['text-role'] ?? 'all') as SearchArgs['textRole'];
+      if (textRole !== 'user' && textRole !== 'assistant' && textRole !== 'all') {
+        throw cliError('INVALID_ARGS', '--text-role must be one of: user, assistant, all');
       }
 
       // Validate --since and --after mutual exclusivity
@@ -2375,11 +2833,18 @@ const searchCommand = defineCommand({
         throw cliError('INVALID_ARGS', '--sort must be one of: session-newest, match-earliest, match-newest, project');
       }
       const aggregateMode = (args.aggregate ?? 'none') as SearchAggregateMode;
-      if (aggregateMode !== 'none' && aggregateMode !== 'count-per-session') {
-        throw cliError('INVALID_ARGS', '--aggregate must be count-per-session');
+      if (aggregateMode !== 'none' && aggregateMode !== 'count-per-session' && aggregateMode !== 'counters') {
+        throw cliError('INVALID_ARGS', '--aggregate must be one of: count-per-session, counters');
       }
-      if (aggregateMode !== 'none' && !args.tool && !args['input-match']) {
-        throw cliError('INVALID_ARGS', '--aggregate requires --tool or --input-match');
+      if (aggregateMode === 'count-per-session' && !args.tool && !args['input-match'] && !args['input-regex']) {
+        throw cliError('INVALID_ARGS', '--aggregate requires --tool, --input-match, or --input-regex');
+      }
+      const bucketMode = (args.bucket ?? 'none') as SearchBucketMode;
+      if (bucketMode !== 'none' && bucketMode !== 'day' && bucketMode !== 'week') {
+        throw cliError('INVALID_ARGS', '--bucket must be one of: day, week');
+      }
+      if (bucketMode !== 'none' && aggregateMode !== 'counters') {
+        throw cliError('INVALID_ARGS', '--bucket requires --aggregate counters');
       }
 
       const origin = Boolean(args.origin);
@@ -2401,17 +2866,63 @@ const searchCommand = defineCommand({
         throw cliError('INVALID_ARGS', '--last must be a positive integer');
       }
 
-      const searchArgs: SearchArgs = {
+      const parseCliRegexMatcher = (pattern: string | undefined, flagName: string): TextMatcher | null => {
+        try {
+          return parseRegexMatcher(pattern, flagName);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw cliError('INVALID_ARGS', message);
+        }
+      };
+
+      const counters = (() => {
+        try {
+          return parseCounterArgs(
+            rawArgs.counter as string | string[] | undefined,
+            rawArgs['counter-regex'] as string | string[] | undefined,
+          );
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw cliError('INVALID_ARGS', message);
+        }
+      })();
+      if (aggregateMode === 'counters' && counters.length === 0) {
+        throw cliError('INVALID_ARGS', '--aggregate counters requires at least one --counter or --counter-regex');
+      }
+      if (aggregateMode !== 'counters' && counters.length > 0) {
+        throw cliError('INVALID_ARGS', '--counter and --counter-regex require --aggregate counters');
+      }
+
+      const searchArgs: PreparedSearchArgs = {
         tool: args.tool,
         inputMatch: args['input-match'],
+        inputRegex: args['input-regex'],
+        inputMatcher: args['input-regex']
+          ? parseCliRegexMatcher(args['input-regex'], '--input-regex')
+          : parseSubstringMatcher(args['input-match']),
         file: args.file,
         text: args.text,
+        textRegex: args['text-regex'],
+        textRole,
+        textMatcher: args['text-regex']
+          ? parseCliRegexMatcher(args['text-regex'], '--text-regex')
+          : parseSubstringMatcher(args.text),
         bash: args.bash,
+        bashRegex: args['bash-regex'],
+        bashMatcher: args['bash-regex']
+          ? parseCliRegexMatcher(args['bash-regex'], '--bash-regex')
+          : parseSubstringMatcher(args.bash),
+        intentMatch: args['intent-match'],
+        intentRegex: args['intent-regex'],
+        intentMatcher: args['intent-regex']
+          ? parseCliRegexMatcher(args['intent-regex'], '--intent-regex')
+          : parseSubstringMatcher(args['intent-match']),
         branch: args.branch,
         after: args.after,
         before: args.before,
         since: args.since,
         operation: origin ? 'write' : args.operation as SearchOperation | undefined,
+        includeSubagents: args.subagents !== false && !(args as Record<string, unknown>)['no-subagents'],
       };
 
       const allProjects = Boolean(args['all-projects']);
@@ -2434,7 +2945,20 @@ const searchCommand = defineCommand({
       const total = results.length;
       const resultLimit = origin ? lastN ?? 1 : lastN;
       const returned = resultLimit != null ? results.slice(0, resultLimit) : results;
-      const responseMeta: SearchMeta = meta(total, returned.length);
+      let responseData: unknown = returned;
+      let responseMeta: SearchMeta = meta(total, returned.length);
+      if (aggregateMode === 'count-per-session') {
+        responseData = aggregateSearchMatches(returned, aggregateMode);
+      } else if (aggregateMode === 'counters') {
+        const explicitSelector = Boolean(args.tool || args['input-match'] || args['input-regex'] || args.file || args.text || args['text-regex'] || args.bash || args['bash-regex'] || args['intent-match'] || args['intent-regex']);
+        const counterRows = aggregateCounterRows(returned, counters, {
+          tool: args.tool,
+          explicitSelector,
+          perSubagent: Boolean(args['per-subagent']),
+        });
+        responseData = bucketMode === 'none' ? counterRows : bucketCounterRows(counterRows, bucketMode);
+        responseMeta = meta(Array.isArray(responseData) ? responseData.length : 0, Array.isArray(responseData) ? responseData.length : 0);
+      }
       if (allProjects) {
         responseMeta.projects_scanned = selection.contexts.length;
         responseMeta.included_projects = selection.includedProjects;
@@ -2442,10 +2966,7 @@ const searchCommand = defineCommand({
       } else {
         responseMeta.included_projects = selection.includedProjects;
       }
-      output(success(
-        aggregateMode === 'count-per-session' ? aggregateSearchMatches(returned, aggregateMode) : returned,
-        responseMeta,
-      ));
+      output(success(responseData, responseMeta));
     } catch (err: unknown) {
       handleCommandError(err);
     }
@@ -2488,11 +3009,13 @@ const main = defineCommand({
   meta: {
     name: 'cc-session-tool',
     version: VERSION,
-    description: 'Query Claude Code session transcripts',
+    description: 'Query Claude Code session transcripts with stable raw project/session_ref handles',
   },
   subCommands: {
     list: listCommand,
+    projects: projectsCommand,
     shape: shapeCommand,
+    summary: summaryCommand,
     messages: messagesCommand,
     tools: toolsCommand,
     tokens: tokensCommand,

--- a/index.ts
+++ b/index.ts
@@ -123,6 +123,7 @@ export type ListSession = {
   branch: string | null;
   timestamp: string | null;
   version: string | null;
+  model: string | null;
   lines: number;
   slug: string | null;
   subagent_count?: number;
@@ -1156,7 +1157,7 @@ async function listSessionsForContext(
 
         if (minLines > 0 && lineCount < minLines) return null;
 
-        const { branch, timestamp, version, slug } = extractSessionMetadata(text);
+        const { branch, timestamp, version, slug, model } = extractSessionMetadata(text);
 
         if (args.branch && branch !== args.branch) return null;
         if (afterCutoff) {
@@ -1171,7 +1172,7 @@ async function listSessionsForContext(
           if (!intents.some(intent => testTextMatcher(intentMatcher, intent.value))) return null;
         }
 
-        const session: ListSession = { session_id: sessionId, branch, timestamp, version, lines: lineCount, slug };
+        const session: ListSession = { session_id: sessionId, branch, timestamp, version, model, lines: lineCount, slug };
         if (includeIdentityFields) {
           session.project = context.projectRef.project;
           session.project_path_guess = context.projectRef.project_path_guess;

--- a/src/project-selection.ts
+++ b/src/project-selection.ts
@@ -1,0 +1,606 @@
+import { homedir } from 'os';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'path';
+import { existsSync, readdirSync, realpathSync } from 'fs';
+import type { SessionEntry } from './transcript.ts';
+
+export type ProjectRef = {
+  project: string;
+  claude_dir: string;
+  project_path_guess: string | null;
+};
+
+export type SearchOperation = 'read' | 'edit' | 'write' | 'grep' | 'glob';
+
+export type SearchProjectRole = 'main' | 'worktree' | 'global';
+
+export type PublicProjectRef = {
+  project: string;
+  project_path_guess: string | null;
+  project_role: SearchProjectRole;
+};
+
+export type ProjectSummary = {
+  project: string;
+  project_path_guess: string | null;
+  project_role: SearchProjectRole;
+  session_count: number;
+  total_lines: number;
+  first_session_at: string | null;
+  last_session_at: string | null;
+};
+
+export type SearchProjectContext = {
+  role: SearchProjectRole;
+  projectRoot: string | null;
+  worktreeRoot: string | null;
+  queryAnchorRoot?: string | null;
+  projectRef: ProjectRef;
+};
+
+export type SearchSessionContext = SearchProjectContext & {
+  sessionCwd: string | null;
+  worktreeStateOriginalCwd: string | null;
+  worktreeStateWorktreePath: string | null;
+  queryAnchorRoot: string | null;
+  normalizedProjectRoots: string[];
+  normalizedWorktreeRoots: string[];
+  pathCandidateCache: Map<string, string[]>;
+};
+
+export type WorktreeStatePaths = {
+  originalCwd: string | null;
+  worktreePath: string | null;
+};
+
+export type NormalizedFileQuery = {
+  raw: string;
+  rawLower: string;
+  logicalPath: string | null;
+  absoluteCandidates: string[];
+};
+
+export type NormalizedFileAccess = {
+  rawPath: string;
+  operation: SearchOperation;
+  logicalPath: string | null;
+  absoluteCandidates: string[];
+};
+
+export type FileMatchKind = 'canonical' | 'logical' | 'substring';
+
+export type FileMatchResult = {
+  matched: boolean;
+  matchedBy: FileMatchKind;
+  logicalPath: string | null;
+};
+
+export type SearchTarget = {
+  filePath: string;
+  sessionId: string;
+  context?: SearchProjectContext;
+  projectRef?: ProjectRef;
+};
+
+export type SearchScopeOptions = {
+  projectPath: string;
+  claudeProjectsRoot?: string;
+  includeWorktrees: boolean;
+};
+
+export type SearchScope = {
+  projectRoot: string;
+  projects: SearchProjectContext[];
+};
+
+export type ProjectSelectionMode = 'scoped' | 'scoped-with-worktrees' | 'all-projects';
+
+export type ProjectSelectionOptions = {
+  mode: ProjectSelectionMode;
+  projectPath?: string;
+  projectGlob?: string;
+  claudeProjectsRoot?: string;
+};
+
+export type ProjectSelection = {
+  contexts: SearchProjectContext[];
+  includedProjects: PublicProjectRef[];
+  skippedProjects: PublicProjectRef[];
+};
+
+export type SessionProjectSelector =
+  | { kind: 'projectPath'; projectPath: string }
+  | { kind: 'claudeProject'; project: string };
+
+export function claudeProjectsRoot(home = homedir()): string {
+  return join(home, '.claude', 'projects');
+}
+
+function stripTrailingSlashes(input: string): string {
+  return input.replace(/\/+$/, '') || '/';
+}
+
+export function normalizePathForContainment(input: string): string {
+  return stripTrailingSlashes(resolve(input));
+}
+
+export function mangleProjectPath(projectPath: string): string {
+  const normalized = normalizePathForContainment(projectPath);
+  const stripped = normalized.startsWith('/') ? normalized.slice(1) : normalized;
+  return '-' + stripped.replace(/\//g, '-');
+}
+
+export function projectPathGuessFromClaudeProject(projectName: string): string | null {
+  if (!projectName.startsWith('-')) return null;
+  return '/' + projectName.slice(1).replace(/-/g, '/');
+}
+
+export function listClaudeProjectRefs(root = claudeProjectsRoot()): ProjectRef[] {
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(d => ({
+      project: d.name,
+      claude_dir: join(root, d.name),
+      project_path_guess: projectPathGuessFromClaudeProject(d.name),
+    }));
+}
+
+export function isPathWithinOrEqual(pathname: string, root: string): boolean {
+  const normalizedPath = normalizePathForContainment(pathname);
+  const normalizedRoot = normalizePathForContainment(root);
+  const rel = relative(normalizedRoot, normalizedPath);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+export function pathContainmentCandidates(pathname: string): string[] {
+  const candidates = new Set<string>([normalizePathForContainment(pathname)]);
+  try {
+    candidates.add(normalizePathForContainment(realpathSync.native(pathname)));
+  } catch {
+    // Missing fixture paths are common in transcript tests; keep the lexical candidate.
+  }
+  let existingAncestor = normalizePathForContainment(pathname);
+  const missingSegments: string[] = [];
+  while (!existsSync(existingAncestor)) {
+    const parent = dirname(existingAncestor);
+    if (parent === existingAncestor) break;
+    missingSegments.unshift(basename(existingAncestor));
+    existingAncestor = parent;
+  }
+  if (existsSync(existingAncestor)) {
+    try {
+      candidates.add(normalizePathForContainment(join(realpathSync.native(existingAncestor), ...missingSegments)));
+    } catch {
+      // Keep candidates collected so far.
+    }
+  }
+  return Array.from(candidates);
+}
+
+function uniqueNormalizedCandidates(paths: Array<string | null | undefined>): string[] {
+  const candidates = new Set<string>();
+  for (const pathname of paths) {
+    if (!pathname || !isAbsolute(pathname)) continue;
+    for (const candidate of pathContainmentCandidates(pathname)) {
+      candidates.add(candidate);
+    }
+  }
+  return Array.from(candidates);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeLogicalRelativePath(pathname: string): string {
+  return pathname.split('/').filter(part => part.length > 0).join('/');
+}
+
+function logicalPathForAbsoluteCandidates(candidates: string[], roots: string[]): string | null {
+  const orderedRoots = [...roots].sort((a, b) => b.length - a.length);
+  for (const candidate of candidates) {
+    for (const root of orderedRoots) {
+      if (!isPathWithinOrEqual(candidate, root)) continue;
+      const rel = relative(root, candidate);
+      if (!rel || rel.startsWith('..') || isAbsolute(rel)) continue;
+      return normalizeLogicalRelativePath(rel);
+    }
+  }
+  return null;
+}
+
+export function absolutePathCandidatesFor(pathname: string, context: SearchSessionContext): string[] {
+  if (!isAbsolute(pathname)) return [];
+  const cached = context.pathCandidateCache.get(pathname);
+  if (cached) return cached;
+  const candidates = pathContainmentCandidates(pathname);
+  context.pathCandidateCache.set(pathname, candidates);
+  return candidates;
+}
+
+export function deriveWorktreeRootFromPath(projectRoot: string | null, pathname: string | null): string | null {
+  if (!projectRoot || !pathname || !isAbsolute(pathname)) return null;
+
+  for (const projectCandidate of pathContainmentCandidates(projectRoot)) {
+    const worktreesRoot = normalizePathForContainment(join(projectCandidate, '.claude', 'worktrees'));
+    for (const pathCandidate of pathContainmentCandidates(pathname)) {
+      if (!isPathWithinOrEqual(pathCandidate, worktreesRoot)) continue;
+      const rel = relative(worktreesRoot, pathCandidate);
+      if (!rel || rel.startsWith('..') || isAbsolute(rel)) continue;
+      const [worktreeDir] = rel.split('/');
+      if (!worktreeDir) continue;
+      return normalizePathForContainment(join(worktreesRoot, worktreeDir));
+    }
+  }
+
+  return null;
+}
+
+export function extractSessionCwd(entries: SessionEntry[]): string | null {
+  for (const entry of entries) {
+    if (typeof entry.cwd === 'string' && entry.cwd.trim()) return entry.cwd;
+  }
+  return null;
+}
+
+export function extractWorktreeStatePaths(entries: SessionEntry[]): WorktreeStatePaths {
+  const paths: WorktreeStatePaths = { originalCwd: null, worktreePath: null };
+
+  for (const entry of entries) {
+    const record = entry as unknown as Record<string, unknown>;
+    for (const key of ['worktree-state', 'worktreeState']) {
+      const state = record[key];
+      if (!isRecord(state)) continue;
+      if (paths.originalCwd === null && typeof state.originalCwd === 'string' && state.originalCwd.trim()) {
+        paths.originalCwd = state.originalCwd;
+      }
+      if (paths.worktreePath === null && typeof state.worktreePath === 'string' && state.worktreePath.trim()) {
+        paths.worktreePath = state.worktreePath;
+      }
+    }
+    if (paths.originalCwd !== null && paths.worktreePath !== null) break;
+  }
+
+  return paths;
+}
+
+function equivalentAbsolutePath(a: string | null, b: string | null): boolean {
+  if (!a || !b || !isAbsolute(a) || !isAbsolute(b)) return false;
+  const bCandidates = new Set(pathContainmentCandidates(b));
+  return pathContainmentCandidates(a).some(candidate => bCandidates.has(candidate));
+}
+
+function acceptedProjectRoot(projectRoot: string | null, candidate: string | null): string | null {
+  return equivalentAbsolutePath(projectRoot, candidate) ? candidate : null;
+}
+
+function acceptedWorktreeRoot(projectRoot: string | null, candidate: string | null): string | null {
+  if (!projectRoot || !candidate || !isAbsolute(candidate)) return null;
+  return deriveWorktreeRootFromPath(projectRoot, candidate);
+}
+
+function extractFilePath(toolName: string, input: Record<string, unknown>): { path: string; operation: SearchOperation } | null {
+  const fileAccess = (key: 'file_path' | 'path', operation: SearchOperation): { path: string; operation: SearchOperation } | null => {
+    const value = input[key];
+    return typeof value === 'string' && value.trim() ? { path: value, operation } : null;
+  };
+
+  switch (toolName) {
+    case 'Read':
+      return fileAccess('file_path', 'read');
+    case 'Edit':
+      return fileAccess('file_path', 'edit');
+    case 'Write':
+      return fileAccess('file_path', 'write');
+    case 'Grep':
+      return fileAccess('path', 'grep');
+    case 'Glob':
+      return fileAccess('path', 'glob');
+    default:
+      return null;
+  }
+}
+
+export function collectObservedWorktreeRoots(entries: SessionEntry[], projectRoot: string | null): string[] {
+  const observed = new Set<string>();
+  if (!projectRoot) return [];
+
+  for (const entry of entries) {
+    const content = entry.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block.type !== 'tool_use' || !block.name) continue;
+      const fileInfo = extractFilePath(block.name, block.input ?? {});
+      if (!fileInfo || !isAbsolute(fileInfo.path)) continue;
+      const worktreeRoot = acceptedWorktreeRoot(projectRoot, fileInfo.path);
+      if (worktreeRoot) observed.add(worktreeRoot);
+    }
+  }
+
+  return Array.from(observed);
+}
+
+export function buildSearchSessionContext(context: SearchProjectContext, entries: SessionEntry[]): SearchSessionContext {
+  const sessionCwd = extractSessionCwd(entries);
+  const worktreeStatePaths = extractWorktreeStatePaths(entries);
+  const queryAnchorRoot = context.queryAnchorRoot ?? null;
+  const identityRoot = context.projectRoot ?? queryAnchorRoot;
+  const projectRootCandidates = [
+    context.projectRoot,
+    queryAnchorRoot,
+    acceptedProjectRoot(identityRoot, sessionCwd),
+    acceptedProjectRoot(identityRoot, worktreeStatePaths.originalCwd),
+  ];
+  const worktreeRootCandidates = [
+    context.worktreeRoot,
+    acceptedWorktreeRoot(identityRoot, sessionCwd),
+    acceptedWorktreeRoot(identityRoot, worktreeStatePaths.originalCwd),
+    acceptedWorktreeRoot(identityRoot, worktreeStatePaths.worktreePath),
+    ...collectObservedWorktreeRoots(entries, identityRoot),
+  ];
+  return {
+    ...context,
+    sessionCwd,
+    worktreeStateOriginalCwd: worktreeStatePaths.originalCwd,
+    worktreeStateWorktreePath: worktreeStatePaths.worktreePath,
+    queryAnchorRoot,
+    normalizedProjectRoots: uniqueNormalizedCandidates(projectRootCandidates),
+    normalizedWorktreeRoots: uniqueNormalizedCandidates(worktreeRootCandidates),
+    pathCandidateCache: new Map<string, string[]>(),
+  };
+}
+
+export function normalizeFileQuery(raw: string, context: SearchSessionContext): NormalizedFileQuery {
+  const absoluteCandidates = absolutePathCandidatesFor(raw, context);
+  const logicalPath = absoluteCandidates.length > 0
+    ? logicalPathForAbsoluteCandidates(absoluteCandidates, context.normalizedProjectRoots)
+    : null;
+  return {
+    raw,
+    rawLower: raw.toLowerCase(),
+    logicalPath,
+    absoluteCandidates,
+  };
+}
+
+export function normalizeFileAccess(
+  rawPath: string,
+  operation: SearchOperation,
+  context: SearchSessionContext,
+): NormalizedFileAccess {
+  const identityRoot = context.projectRoot ?? context.queryAnchorRoot;
+  const observedWorktreeRoot = deriveWorktreeRootFromPath(identityRoot, rawPath);
+  const roots = [
+    ...context.normalizedProjectRoots,
+    ...context.normalizedWorktreeRoots,
+    ...uniqueNormalizedCandidates([observedWorktreeRoot]),
+  ];
+  const absoluteCandidates = absolutePathCandidatesFor(rawPath, context);
+  const logicalPath = absoluteCandidates.length > 0
+    ? logicalPathForAbsoluteCandidates(absoluteCandidates, roots)
+    : null;
+  return { rawPath, operation, logicalPath, absoluteCandidates };
+}
+
+export function matchFileAccess(query: NormalizedFileQuery, access: NormalizedFileAccess): FileMatchResult {
+  if (query.absoluteCandidates.length > 0 && access.absoluteCandidates.length > 0) {
+    const accessCandidates = new Set(access.absoluteCandidates);
+    if (query.absoluteCandidates.some(candidate => accessCandidates.has(candidate))) {
+      return {
+        matched: true,
+        matchedBy: 'canonical',
+        logicalPath: access.logicalPath ?? query.logicalPath,
+      };
+    }
+  }
+
+  if (query.logicalPath != null) {
+    const matched = access.logicalPath === query.logicalPath;
+    return {
+      matched,
+      matchedBy: 'logical',
+      logicalPath: matched ? access.logicalPath : null,
+    };
+  }
+
+  return {
+    matched: access.rawPath.toLowerCase().includes(query.rawLower),
+    matchedBy: 'substring',
+    logicalPath: access.logicalPath,
+  };
+}
+
+export function findRelatedProjectRefs(projectPath: string, refs: ProjectRef[]): ProjectRef[] {
+  const normalizedProject = normalizePathForContainment(projectPath);
+  const worktreesDirPrefix = `${mangleProjectPath(join(normalizedProject, '.claude', 'worktrees'))}-`;
+  const doubleDashWorktreePrefix = `${mangleProjectPath(normalizedProject)}--claude-worktrees-`;
+  const related: ProjectRef[] = [];
+  const seen = new Set<string>();
+
+  for (const ref of refs) {
+    if (!ref.project.startsWith(worktreesDirPrefix) && !ref.project.startsWith(doubleDashWorktreePrefix)) {
+      continue;
+    }
+    if (seen.has(ref.project)) continue;
+    seen.add(ref.project);
+    related.push(ref);
+  }
+
+  return related;
+}
+
+export function buildScopedSearchScope(options: SearchScopeOptions): SearchScope {
+  const projectRoot = normalizePathForContainment(options.projectPath);
+  const root = options.claudeProjectsRoot ?? claudeProjectsRoot();
+  const mainProjectRef: ProjectRef = {
+    project: mangleProjectPath(options.projectPath),
+    claude_dir: resolveClaudeProjectDir(options.projectPath, root),
+    project_path_guess: options.projectPath,
+  };
+  const projects: SearchProjectContext[] = [{
+    role: 'main',
+    projectRoot: options.projectPath,
+    worktreeRoot: null,
+    projectRef: mainProjectRef,
+  }];
+
+  if (options.includeWorktrees) {
+    for (const ref of findRelatedProjectRefs(options.projectPath, listClaudeProjectRefs(root))) {
+      projects.push({
+        role: 'worktree',
+        projectRoot: options.projectPath,
+        worktreeRoot: null,
+        projectRef: ref,
+      });
+    }
+  }
+
+  return { projectRoot, projects };
+}
+
+function publicProjectRef(context: SearchProjectContext): PublicProjectRef {
+  return {
+    project: context.projectRef.project,
+    project_path_guess: context.projectRef.project_path_guess,
+    project_role: context.role,
+  };
+}
+
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  const pattern = escaped.replace(/\*/g, '.*').replace(/\?/g, '.');
+  return new RegExp(`^${pattern}$`);
+}
+
+function projectMatchesPattern(ref: ProjectRef, regex: RegExp): boolean {
+  return regex.test(ref.project) || Boolean(ref.project_path_guess && regex.test(ref.project_path_guess));
+}
+
+export function projectMatchesGlob(ref: ProjectRef, glob: string): boolean {
+  return projectMatchesPattern(ref, globToRegExp(glob));
+}
+
+export function selectProjectContexts(options: ProjectSelectionOptions): ProjectSelection {
+  const root = options.claudeProjectsRoot ?? claudeProjectsRoot();
+
+  if (options.mode === 'all-projects') {
+    const included: SearchProjectContext[] = [];
+    const skipped: SearchProjectContext[] = [];
+    const projectGlobRegex = options.projectGlob ? globToRegExp(options.projectGlob) : null;
+    const queryAnchorRoot = options.projectPath ?? null;
+    for (const projectRef of listClaudeProjectRefs(root)) {
+      const context: SearchProjectContext = {
+        role: 'global',
+        projectRoot: null,
+        worktreeRoot: null,
+        queryAnchorRoot,
+        projectRef,
+      };
+      if (projectGlobRegex && !projectMatchesPattern(projectRef, projectGlobRegex)) {
+        skipped.push(context);
+      } else {
+        included.push(context);
+      }
+    }
+    return {
+      contexts: included,
+      includedProjects: included.map(publicProjectRef),
+      skippedProjects: skipped.map(publicProjectRef),
+    };
+  }
+
+  const projectPath = options.projectPath || process.cwd();
+  const scope = buildScopedSearchScope({
+    projectPath,
+    claudeProjectsRoot: root,
+    includeWorktrees: options.mode === 'scoped-with-worktrees',
+  });
+  return {
+    contexts: scope.projects,
+    includedProjects: scope.projects.map(publicProjectRef),
+    skippedProjects: [],
+  };
+}
+
+export function resolveClaudeProjectDir(projectPath: string, root = claudeProjectsRoot()): string {
+  const claudeDir = join(root, mangleProjectPath(projectPath));
+  if (!existsSync(claudeDir)) {
+    throw new Error(`Claude project directory not found: ${claudeDir}`);
+  }
+  return claudeDir;
+}
+
+export function validateClaudeProjectBasename(project: string): void {
+  if (
+    !project ||
+    project === '.' ||
+    project === '..' ||
+    project.includes('/') ||
+    project.includes('\\') ||
+    basename(project) !== project
+  ) {
+    throw new Error('--claude-project must be a Claude project directory basename');
+  }
+}
+
+function readRawStringOption(name: string): string | undefined {
+  const longName = `--${name}`;
+  const withEquals = `${longName}=`;
+  for (let i = 2; i < process.argv.length; i++) {
+    const arg = process.argv[i]!;
+    if (arg.startsWith(withEquals)) {
+      return arg.slice(withEquals.length);
+    }
+    if (arg === longName) {
+      const value = process.argv[i + 1];
+      return value && !value.startsWith('--') ? value : undefined;
+    }
+  }
+  return undefined;
+}
+
+export function resolveClaudeProjectDirFromSelector(
+  selector: SessionProjectSelector,
+  root = claudeProjectsRoot(),
+): string {
+  if (selector.kind === 'projectPath') {
+    return resolveClaudeProjectDir(selector.projectPath, root);
+  }
+
+  validateClaudeProjectBasename(selector.project);
+  const claudeDir = join(root, selector.project);
+  if (!existsSync(claudeDir)) {
+    throw new Error(`Claude project directory not found: ${claudeDir}`);
+  }
+  return claudeDir;
+}
+
+export function sessionProjectSelectorFromArgs(args: {
+  project?: string;
+  'claude-project'?: string;
+}): SessionProjectSelector {
+  const claudeProject = readRawStringOption('claude-project') ?? (
+    typeof args['claude-project'] === 'string' ? args['claude-project'] : undefined
+  );
+  if (args.project && claudeProject) {
+    throw new Error('--project and --claude-project are mutually exclusive');
+  }
+  if (claudeProject) {
+    return { kind: 'claudeProject', project: claudeProject };
+  }
+  return { kind: 'projectPath', projectPath: args.project || process.cwd() };
+}
+
+export function listSearchTargetsForContext(context: SearchProjectContext): SearchTarget[] {
+  if (!existsSync(context.projectRef.claude_dir)) return [];
+  return readdirSync(context.projectRef.claude_dir)
+    .filter(f => f.endsWith('.jsonl'))
+    .sort((a, b) => a.localeCompare(b))
+    .map(f => ({
+      filePath: join(context.projectRef.claude_dir, f),
+      sessionId: f.replace('.jsonl', ''),
+      context,
+      projectRef: context.projectRef,
+    }));
+}

--- a/src/project-selection.ts
+++ b/src/project-selection.ts
@@ -111,6 +111,22 @@ export type SessionProjectSelector =
   | { kind: 'projectPath'; projectPath: string }
   | { kind: 'claudeProject'; project: string };
 
+export type ProjectSelectionErrorCode = 'INVALID_ARGS' | 'NOT_FOUND';
+
+export class ProjectSelectionError extends Error {
+  readonly code: ProjectSelectionErrorCode;
+
+  constructor(code: ProjectSelectionErrorCode, message: string) {
+    super(message);
+    this.code = code;
+    this.name = 'ProjectSelectionError';
+  }
+}
+
+export function isProjectSelectionError(err: unknown): err is ProjectSelectionError {
+  return err instanceof ProjectSelectionError;
+}
+
 export function claudeProjectsRoot(home = homedir()): string {
   return join(home, '.claude', 'projects');
 }
@@ -526,7 +542,7 @@ export function selectProjectContexts(options: ProjectSelectionOptions): Project
 export function resolveClaudeProjectDir(projectPath: string, root = claudeProjectsRoot()): string {
   const claudeDir = join(root, mangleProjectPath(projectPath));
   if (!existsSync(claudeDir)) {
-    throw new Error(`Claude project directory not found: ${claudeDir}`);
+    throw new ProjectSelectionError('NOT_FOUND', `Claude project directory not found: ${claudeDir}`);
   }
   return claudeDir;
 }
@@ -540,7 +556,7 @@ export function validateClaudeProjectBasename(project: string): void {
     project.includes('\\') ||
     basename(project) !== project
   ) {
-    throw new Error('--claude-project must be a Claude project directory basename');
+    throw new ProjectSelectionError('INVALID_ARGS', '--claude-project must be a Claude project directory basename');
   }
 }
 
@@ -571,7 +587,7 @@ export function resolveClaudeProjectDirFromSelector(
   validateClaudeProjectBasename(selector.project);
   const claudeDir = join(root, selector.project);
   if (!existsSync(claudeDir)) {
-    throw new Error(`Claude project directory not found: ${claudeDir}`);
+    throw new ProjectSelectionError('NOT_FOUND', `Claude project directory not found: ${claudeDir}`);
   }
   return claudeDir;
 }
@@ -584,7 +600,7 @@ export function sessionProjectSelectorFromArgs(args: {
     typeof args['claude-project'] === 'string' ? args['claude-project'] : undefined
   );
   if (args.project && claudeProject) {
-    throw new Error('--project and --claude-project are mutually exclusive');
+    throw new ProjectSelectionError('INVALID_ARGS', '--project and --claude-project are mutually exclusive');
   }
   if (claudeProject) {
     return { kind: 'claudeProject', project: claudeProject };

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,0 +1,492 @@
+import type {
+  SearchProjectContext,
+  PublicProjectRef,
+  ProjectRef,
+  SearchOperation,
+  SearchProjectRole,
+} from './project-selection.ts';
+import type { SessionMetadata } from './transcript.ts';
+
+export const SEARCH_EVIDENCE_SNIPPET_CHARS = 200;
+export const SUMMARY_SNIPPET_CHARS = 400;
+
+export type MatchMode = 'substring' | 'regex';
+
+export type TextMatcher = {
+  raw: string;
+  mode: MatchMode;
+  regex?: RegExp;
+  needleLower?: string;
+};
+
+export type SessionRef = {
+  session_id: string;
+  project: string;
+  agent_id?: string | null;
+};
+
+export type IntentMatchSource = 'slug' | 'first_prompt' | 'first_message';
+
+export type SearchEvidenceKind =
+  | 'file'
+  | 'tool_input'
+  | 'text'
+  | 'thinking'
+  | 'bash'
+  | 'intent';
+
+export type SearchEvidence = {
+  kind: SearchEvidenceKind;
+  turn: number;
+  block_index: number | null;
+  timestamp: string | null;
+  role?: 'user' | 'assistant';
+  agent_id?: string | null;
+  parent_session_id?: string | null;
+  is_subagent?: boolean;
+  snippet?: string;
+
+  rawPath?: string;
+  logicalPath?: string | null;
+  operation?: SearchOperation;
+
+  tool?: string;
+  input_summary?: string;
+  intent_source?: IntentMatchSource;
+};
+
+export type SearchMatch = {
+  session_id: string;
+  branch: string | null;
+  timestamp: string | null;
+  slug: string | null;
+  model: string | null;
+  project?: string;
+  project_path_guess?: string | null;
+  project_role?: SearchProjectRole;
+  session_ref: SessionRef;
+  agent_id?: string | null;
+  parent_session_id?: string | null;
+  is_subagent?: boolean;
+  matches: {
+    tools: string[];
+    files: string[];
+    normalized_files?: string[];
+    operations?: SearchOperation[];
+    turns: number[];
+    evidence: SearchEvidence[];
+  };
+};
+
+export type ToolInputMatch = {
+  tool: string;
+  input_summary: string;
+  turn: number;
+};
+
+export type SearchAggregateMode = 'none' | 'count-per-session' | 'counters';
+export type SearchBucketMode = 'none' | 'day' | 'week';
+
+export type SearchCounterAggregateResult = {
+  session_id: string;
+  branch: string | null;
+  timestamp: string | null;
+  slug: string | null;
+  model: string | null;
+  project: string;
+  project_path_guess: string | null;
+  project_role: SearchProjectRole;
+  session_ref: SessionRef;
+  parent_session_id?: string | null;
+  agent_id?: string | null;
+  is_subagent?: boolean;
+  counts: Record<string, number>;
+  total_matches: number;
+};
+
+export type SearchBucketAggregateResult = {
+  bucket: string;
+  sessions: number;
+  counts: Record<string, number>;
+  total_matches: number;
+};
+
+export type ResponseMeta = {
+  total: number;
+  returned: number;
+  hasMore: boolean;
+};
+
+export type SearchMeta = ResponseMeta & {
+  projects_scanned?: number;
+  included_projects?: PublicProjectRef[];
+  skipped_projects?: PublicProjectRef[];
+};
+
+export type SearchTranscriptTarget = {
+  filePath: string;
+  sessionId: string;
+  parentSessionId: string | null;
+  agentId: string | null;
+  context?: SearchProjectContext;
+  projectRef?: ProjectRef;
+};
+
+export type SearchSessionGroup = {
+  parent: SearchTranscriptTarget;
+  subagents: SearchTranscriptTarget[];
+};
+
+export type ToolCallScanRecord = {
+  turn: number;
+  block_index: number;
+  timestamp: string | null;
+  tool: string;
+  input_summary: string;
+  rawInput: Record<string, unknown>;
+  agentId: string | null;
+  parentSessionId: string | null;
+  isSubagent: boolean;
+};
+
+export type TranscriptScanResult = {
+  target: SearchTranscriptTarget;
+  evidence: SearchEvidence[];
+  allToolCalls: ToolCallScanRecord[];
+  metadata: SessionMetadata;
+};
+
+export type SessionGroupScanResult = {
+  groupRef: SessionRef;
+  parentMetadata: SessionMetadata;
+  transcriptResults: TranscriptScanResult[];
+};
+
+export type ParsedCounter = {
+  name: string;
+  matcher: TextMatcher;
+  source: 'substring' | 'regex';
+};
+
+const COUNTER_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_-]*$/;
+const RESERVED_COUNTER_NAMES = new Set(['__proto__', 'constructor', 'prototype']);
+
+export function parseSubstringMatcher(raw: string | undefined): TextMatcher | null {
+  if (raw === undefined) return null;
+  return {
+    raw,
+    mode: 'substring',
+    needleLower: raw.toLowerCase(),
+  };
+}
+
+export function parseRegexMatcher(raw: string | undefined, flagName: string): TextMatcher | null {
+  if (raw === undefined) return null;
+  try {
+    return {
+      raw,
+      mode: 'regex',
+      regex: new RegExp(raw, 'i'),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid ${flagName} regex: ${message}`);
+  }
+}
+
+export function testTextMatcher(matcher: TextMatcher | null, value: string): boolean {
+  if (!matcher) return true;
+  if (matcher.mode === 'regex') return matcher.regex?.test(value) ?? false;
+  return value.toLowerCase().includes(matcher.needleLower ?? matcher.raw.toLowerCase());
+}
+
+export function snippetForMatch(value: string, matcher: TextMatcher, maxChars: number): string {
+  if (maxChars <= 0 || value.length <= maxChars) return value;
+
+  const match = locateMatch(value, matcher);
+  if (!match) return value.slice(0, maxChars);
+
+  const matchCenter = Math.floor((match.start + match.end) / 2);
+  let start = Math.max(0, matchCenter - Math.floor(maxChars / 2));
+  let end = start + maxChars;
+  if (end > value.length) {
+    end = value.length;
+    start = Math.max(0, end - maxChars);
+  }
+
+  return value.slice(start, end);
+}
+
+function locateMatch(value: string, matcher: TextMatcher): { start: number; end: number } | null {
+  if (matcher.mode === 'regex') {
+    const regex = matcher.regex;
+    if (!regex) return null;
+    regex.lastIndex = 0;
+    const match = regex.exec(value);
+    if (!match || match.index < 0) return null;
+    const matchedText = match[0] ?? '';
+    return {
+      start: match.index,
+      end: match.index + matchedText.length,
+    };
+  }
+
+  const needle = matcher.needleLower ?? matcher.raw.toLowerCase();
+  const start = value.toLowerCase().indexOf(needle);
+  if (start < 0) return null;
+  return { start, end: start + needle.length };
+}
+
+export function parseCounterArgs(
+  substringCounters: string | string[] | undefined,
+  regexCounters: string | string[] | undefined,
+): ParsedCounter[] {
+  return [
+    ...parseCounterArgList(substringCounters, 'substring'),
+    ...parseCounterArgList(regexCounters, 'regex'),
+  ];
+}
+
+function parseCounterArgList(
+  counters: string | string[] | undefined,
+  source: 'substring' | 'regex',
+): ParsedCounter[] {
+  const values = counters === undefined ? [] : Array.isArray(counters) ? counters : [counters];
+  return values.map(value => {
+    const separator = value.indexOf('=');
+    if (separator <= 0) {
+      throw new Error(`Invalid counter '${value}': expected NAME=PATTERN`);
+    }
+
+    const name = value.slice(0, separator);
+    const pattern = value.slice(separator + 1);
+    validateCounterName(name);
+
+    return {
+      name,
+      matcher: source === 'regex'
+        ? parseRegexMatcher(pattern, `--counter-regex ${name}`)!
+        : parseSubstringMatcher(pattern)!,
+      source,
+    };
+  });
+}
+
+function validateCounterName(name: string): void {
+  if (!COUNTER_NAME_PATTERN.test(name)) {
+    throw new Error(`Invalid counter name '${name}': use ${COUNTER_NAME_PATTERN.source}`);
+  }
+  if (RESERVED_COUNTER_NAMES.has(name)) {
+    throw new Error(`Invalid counter name '${name}': reserved name`);
+  }
+}
+
+export function evidenceTimestamps(match: SearchMatch, kind?: SearchEvidenceKind): string[] {
+  return match.matches.evidence
+    .filter(e => !kind || e.kind === kind)
+    .map(e => e.timestamp)
+    .filter((timestamp): timestamp is string => Boolean(timestamp))
+    .sort();
+}
+
+export function toolInputSamplesFromEvidence(evidence: SearchEvidence[], limit = 5): ToolInputMatch[] {
+  return evidence
+    .filter(e => e.kind === 'tool_input' && e.tool)
+    .slice(0, limit)
+    .map(e => ({
+      tool: e.tool!,
+      input_summary: e.input_summary ?? '',
+      turn: e.turn,
+    }));
+}
+
+export function stableJsonStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJsonStringify).join(',')}]`;
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries
+    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableJsonStringify(entryValue)}`)
+    .join(',')}}`;
+}
+
+type CounterAggregateTranscript = {
+  target: SearchTranscriptTarget;
+  metadata: SessionMetadata;
+  allToolCalls: ToolCallScanRecord[];
+};
+
+type CounterAggregateSource = SearchMatch & {
+  __counterTranscriptResults?: CounterAggregateTranscript[];
+};
+
+export function attachCounterTranscriptResults(
+  match: SearchMatch,
+  transcriptResults: CounterAggregateTranscript[],
+): void {
+  Object.defineProperty(match, '__counterTranscriptResults', {
+    value: transcriptResults,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+}
+
+export function aggregateCounterRows(
+  matches: SearchMatch[],
+  counters: ParsedCounter[],
+  options: {
+    tool?: string;
+    explicitSelector: boolean;
+    perSubagent: boolean;
+  },
+): SearchCounterAggregateResult[] {
+  const rows: SearchCounterAggregateResult[] = [];
+
+  for (const match of matches as CounterAggregateSource[]) {
+    const transcriptResults = match.__counterTranscriptResults ?? [];
+    if (options.perSubagent) {
+      for (const transcript of transcriptResults) {
+        const row = counterRowForTranscript(match, transcript, counters, options.tool);
+        if (options.explicitSelector || row.total_matches > 0) rows.push(row);
+      }
+      continue;
+    }
+
+    const counts = emptyCounterCounts(counters);
+    for (const transcript of transcriptResults) {
+      addCounterMatches(counts, transcript.allToolCalls, counters, options.tool);
+    }
+    const row = counterRowBase(match, counts);
+    if (options.explicitSelector || row.total_matches > 0) rows.push(row);
+  }
+
+  return rows;
+}
+
+function counterRowForTranscript(
+  match: SearchMatch,
+  transcript: CounterAggregateTranscript,
+  counters: ParsedCounter[],
+  tool: string | undefined,
+): SearchCounterAggregateResult {
+  const counts = emptyCounterCounts(counters);
+  addCounterMatches(counts, transcript.allToolCalls, counters, tool);
+  const row = counterRowBase(match, counts, transcript.metadata);
+
+  if (transcript.target.agentId) {
+    row.agent_id = transcript.target.agentId;
+    row.parent_session_id = transcript.target.parentSessionId ?? match.session_id;
+    row.is_subagent = true;
+    row.session_ref = {
+      session_id: match.session_id,
+      project: match.session_ref.project,
+      agent_id: transcript.target.agentId,
+    };
+  }
+
+  return row;
+}
+
+function counterRowBase(
+  match: SearchMatch,
+  counts: Record<string, number>,
+  metadata = {
+    branch: match.branch,
+    timestamp: match.timestamp,
+    slug: match.slug,
+    model: match.model,
+  } as SessionMetadata,
+): SearchCounterAggregateResult {
+  return {
+    session_id: match.session_id,
+    branch: metadata.branch,
+    timestamp: metadata.timestamp,
+    slug: metadata.slug,
+    model: metadata.model,
+    project: match.session_ref.project,
+    project_path_guess: match.project_path_guess ?? null,
+    project_role: match.project_role ?? 'main',
+    session_ref: match.session_ref,
+    counts,
+    total_matches: totalCounterMatches(counts),
+  };
+}
+
+function emptyCounterCounts(counters: ParsedCounter[]): Record<string, number> {
+  return Object.fromEntries(counters.map(counter => [counter.name, 0]));
+}
+
+function addCounterMatches(
+  counts: Record<string, number>,
+  toolCalls: ToolCallScanRecord[],
+  counters: ParsedCounter[],
+  tool: string | undefined,
+): void {
+  const toolQuery = tool?.toLowerCase();
+  for (const call of toolCalls) {
+    if (toolQuery && !call.tool.toLowerCase().includes(toolQuery)) continue;
+    const serializedInput = stableJsonStringify(call.rawInput);
+    for (const counter of counters) {
+      if (testTextMatcher(counter.matcher, serializedInput)) {
+        counts[counter.name] = (counts[counter.name] ?? 0) + 1;
+      }
+    }
+  }
+}
+
+function totalCounterMatches(counts: Record<string, number>): number {
+  return Object.values(counts).reduce((sum, count) => sum + count, 0);
+}
+
+export function bucketCounterRows(
+  rows: SearchCounterAggregateResult[],
+  mode: SearchBucketMode,
+): SearchBucketAggregateResult[] {
+  if (mode === 'none') return [];
+  const buckets = new Map<string, SearchBucketAggregateResult>();
+
+  for (const row of rows) {
+    const bucket = bucketForTimestamp(row.timestamp, mode);
+    let aggregate = buckets.get(bucket);
+    if (!aggregate) {
+      aggregate = {
+        bucket,
+        sessions: 0,
+        counts: emptyCountsFromRow(row),
+        total_matches: 0,
+      };
+      buckets.set(bucket, aggregate);
+    }
+    aggregate.sessions += 1;
+    aggregate.total_matches += row.total_matches;
+    for (const [name, count] of Object.entries(row.counts)) {
+      aggregate.counts[name] = (aggregate.counts[name] ?? 0) + count;
+    }
+  }
+
+  return Array.from(buckets.values()).sort((a, b) => {
+    if (a.bucket === 'unknown') return 1;
+    if (b.bucket === 'unknown') return -1;
+    return b.bucket.localeCompare(a.bucket);
+  });
+}
+
+function emptyCountsFromRow(row: SearchCounterAggregateResult): Record<string, number> {
+  return Object.fromEntries(Object.keys(row.counts).map(name => [name, 0]));
+}
+
+function bucketForTimestamp(timestamp: string | null, mode: Exclude<SearchBucketMode, 'none'>): string {
+  if (!timestamp) return 'unknown';
+  if (mode === 'day') return timestamp.slice(0, 10);
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return 'unknown';
+  const day = date.getUTCDay();
+  const mondayOffset = day === 0 ? -6 : 1 - day;
+  const monday = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  monday.setUTCDate(monday.getUTCDate() + mondayOffset);
+  return monday.toISOString().slice(0, 10);
+}

--- a/src/search.ts
+++ b/src/search.ts
@@ -186,7 +186,7 @@ export function parseRegexMatcher(raw: string | undefined, flagName: string): Te
     return {
       raw,
       mode: 'regex',
-      regex: new RegExp(raw, 'i'),
+      regex: new RegExp(raw),
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -1,0 +1,537 @@
+import { basename, join } from 'path';
+import { existsSync, readdirSync } from 'fs';
+import {
+  resolveClaudeProjectDirFromSelector,
+  sessionProjectSelectorFromArgs,
+  type SessionProjectSelector,
+} from './project-selection.ts';
+
+export type TokenUsage = {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+};
+
+export type ContentBlock = {
+  type: 'text' | 'thinking' | 'tool_use' | 'tool_result' | 'image' | 'document' | (string & {});
+  text?: string;
+  thinking?: string;
+  name?: string;
+  id?: string;
+  input?: Record<string, unknown>;
+  tool_use_id?: string;
+  is_error?: boolean;
+  content?: string | ContentBlock[];
+};
+
+export type SessionEntry = {
+  type: 'user' | 'assistant' | 'system' | 'summary' | (string & {});
+  sessionId?: string;
+  timestamp?: string;
+  gitBranch?: string;
+  version?: string;
+  cwd?: string;
+  model?: string;
+  message?: {
+    role?: string;
+    content?: string | ContentBlock[];
+    usage?: TokenUsage;
+    model?: string;
+  };
+  slug?: string;
+};
+
+export type NormalizedBlock = {
+  turn: number;
+  block_index: number;
+  role: 'user' | 'assistant';
+  timestamp: string | null;
+  block: ContentBlock;
+};
+
+export type SessionMetadata = {
+  branch: string | null;
+  timestamp: string | null;
+  version: string | null;
+  slug: string | null;
+  model: string | null;
+};
+
+export type SessionIntent = {
+  source: 'slug' | 'first_prompt' | 'first_message';
+  value: string;
+};
+
+export type ExtractSessionMetadataOptions = {
+  includeSlug?: boolean;
+  maxLines?: number;
+};
+
+export type ResolvedFile = {
+  filePath: string;
+  sessionId: string;
+  agentId: string | null;
+};
+
+export type ResolvedSessionWithText = {
+  sessionId: string;
+  agentId: string | null;
+  filePath: string;
+  text: string;
+  entries: SessionEntry[];
+  allEntries: SessionEntry[];
+  lineCount: number;
+  metadata: SessionMetadata;
+};
+
+export type TruncationKind = 'text' | 'thinking' | 'tool_result' | 'raw_entry';
+
+export type TruncationPolicy = {
+  textMaxChars?: number | null;
+  thinkingMaxChars?: number | null;
+  toolResultMaxChars?: number | null;
+  rawEntryMaxChars?: number | null;
+  defaultMaxChars?: number | null;
+};
+
+export type UserAssistantEntry = SessionEntry & { type: 'user' | 'assistant' };
+
+export type SubagentInfo = {
+  agent_id: string;
+  agent_type: string | null;
+  description: string | null;
+  lines: number;
+  timestamp: string | null;
+};
+
+export type SessionSummaryResult = {
+  session_id: string;
+  agent_id: string | null;
+  branch: string | null;
+  model: string | null;
+  started_at: string | null;
+  ended_at: string | null;
+  duration_ms: number | null;
+  turn_count: number;
+  lines: number | null;
+  slug: string | null;
+  first_user_prompt: {
+    turn: number;
+    snippet: string;
+  } | null;
+  last_assistant_text: {
+    turn: number;
+    snippet: string;
+  } | null;
+  tool_counts: Record<string, number>;
+  files_touched: {
+    read: number;
+    edit: number;
+    write: number;
+    grep: number;
+    glob: number;
+  };
+  subagents: SubagentInfo[];
+};
+
+export function userAssistantEntries(entries: SessionEntry[]): UserAssistantEntry[] {
+  return entries.filter((e): e is UserAssistantEntry => e.type === 'user' || e.type === 'assistant');
+}
+
+export function contentBlocksForEntry(entry: SessionEntry): ContentBlock[] {
+  const rawContent = entry.message?.content;
+  if (typeof rawContent === 'string') return [{ type: 'text', text: rawContent }];
+  if (Array.isArray(rawContent)) return rawContent;
+  return [];
+}
+
+export function normalizedBlocks(entries: SessionEntry[]): NormalizedBlock[] {
+  const relevantEntries = userAssistantEntries(entries);
+  const blocks: NormalizedBlock[] = [];
+  for (let turnIndex = 0; turnIndex < relevantEntries.length; turnIndex++) {
+    const entry = relevantEntries[turnIndex]!;
+    const turn = turnIndex + 1;
+    const content = contentBlocksForEntry(entry);
+    for (let blockIndex = 0; blockIndex < content.length; blockIndex++) {
+      blocks.push({
+        turn,
+        block_index: blockIndex,
+        role: entry.type,
+        timestamp: entry.timestamp ?? null,
+        block: content[blockIndex]!,
+      });
+    }
+  }
+  return blocks;
+}
+
+export function extractSessionIntent(entries: SessionEntry[], metadata?: Pick<SessionMetadata, 'slug'>): SessionIntent[] {
+  const intents: SessionIntent[] = [];
+  if (metadata?.slug) {
+    intents.push({ source: 'slug', value: metadata.slug });
+  }
+
+  const blocks = normalizedBlocks(entries);
+  const firstUserText = blocks.find(block => block.role === 'user' && block.block.type === 'text' && typeof block.block.text === 'string');
+  if (firstUserText?.block.text) {
+    const text = firstUserText.block.text;
+    const firstPromptToken = text.trim().split(/\s+/).find(Boolean);
+    if (firstPromptToken) {
+      intents.push({ source: 'first_prompt', value: firstPromptToken });
+    }
+    intents.push({ source: 'first_message', value: text });
+  }
+
+  return intents;
+}
+
+export function parseSessionText(text: string): SessionEntry[] {
+  const entries: SessionEntry[] = [];
+  let nonEmptyCount = 0;
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    nonEmptyCount++;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        'type' in parsed &&
+        typeof (parsed as Record<string, unknown>).type === 'string'
+      ) {
+        entries.push(parsed as SessionEntry);
+      }
+    } catch {
+      // Skip malformed JSONL rows.
+    }
+  }
+  if (nonEmptyCount > 0 && entries.length === 0) {
+    throw new Error('Session file contains no valid entries');
+  }
+  return entries;
+}
+
+export async function parseSessionLines(filePath: string): Promise<SessionEntry[]> {
+  return parseSessionText(await Bun.file(filePath).text());
+}
+
+export function countNonEmptyLines(text: string): number {
+  let count = 0;
+  let lineHasContent = false;
+
+  for (const char of text) {
+    if (char === '\n') {
+      if (lineHasContent) count++;
+      lineHasContent = false;
+    } else if (char.trim() !== '') {
+      lineHasContent = true;
+    }
+  }
+
+  if (lineHasContent) count++;
+  return count;
+}
+
+function modelFromEntry(entry: SessionEntry): string | null {
+  if (typeof entry.message?.model === 'string' && entry.message.model.trim()) return entry.message.model;
+  if (typeof entry.model === 'string' && entry.model.trim()) return entry.model;
+  return null;
+}
+
+export function extractSessionMetadata(
+  text: string,
+  options: ExtractSessionMetadataOptions = {},
+): SessionMetadata {
+  const includeSlug = options.includeSlug ?? true;
+  const maxLines = options.maxLines ?? 50;
+  let branch: string | null = null;
+  let timestamp: string | null = null;
+  let version: string | null = null;
+  let slug: string | null = null;
+  let model: string | null = null;
+
+  let linesSeen = 0;
+  let lineStart = 0;
+  while (linesSeen < maxLines && lineStart <= text.length) {
+    const newlineIndex = text.indexOf('\n', lineStart);
+    const lineEnd = newlineIndex === -1 ? text.length : newlineIndex;
+    const rawLine = text.slice(lineStart, lineEnd);
+    if (rawLine.trim()) {
+      linesSeen++;
+      try {
+        const entry = JSON.parse(rawLine) as SessionEntry;
+        if (branch === null && entry.sessionId) {
+          branch = entry.gitBranch ?? null;
+          version = entry.version ?? null;
+          timestamp = entry.timestamp ?? null;
+        }
+        if (includeSlug && slug === null && typeof entry.slug === 'string') {
+          slug = entry.slug;
+        }
+        if (model === null) {
+          model = modelFromEntry(entry);
+        }
+        if (branch !== null && (!includeSlug || slug !== null) && model !== null) break;
+      } catch {
+        // Skip malformed metadata rows.
+      }
+    }
+    if (newlineIndex === -1) break;
+    lineStart = newlineIndex + 1;
+  }
+
+  return { branch, timestamp, version, slug, model };
+}
+
+function validateSessionInput(input: string): void {
+  if (!input) throw new Error('Session ID is required');
+  if (!/^[a-zA-Z0-9-]+$/.test(input)) {
+    throw new Error('Invalid session ID -- only alphanumeric characters and hyphens allowed');
+  }
+}
+
+async function fileContainsSlug(filePath: string, slug: string): Promise<boolean> {
+  const slugNeedle = `"slug":"${slug}"`;
+  const stream = Bun.file(filePath).stream();
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffered = '';
+
+  const matchesSlug = (line: string): boolean => {
+    if (!line.includes(slugNeedle)) return false;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      return (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        (parsed as SessionEntry).slug === slug
+      );
+    } catch {
+      return false;
+    }
+  };
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+
+      buffered += decoder.decode(value, { stream: true });
+      let newlineIndex = buffered.indexOf('\n');
+      while (newlineIndex !== -1) {
+        const line = buffered.slice(0, newlineIndex);
+        buffered = buffered.slice(newlineIndex + 1);
+        if (matchesSlug(line)) {
+          try {
+            await reader.cancel();
+          } catch {
+            // Cleanup failures should not change a confirmed match.
+          }
+          return true;
+        }
+        newlineIndex = buffered.indexOf('\n');
+      }
+    }
+    buffered += decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+
+  return buffered.length > 0 && matchesSlug(buffered);
+}
+
+export async function resolveByIdOrSlug(claudeDir: string, input: string): Promise<string> {
+  validateSessionInput(input);
+  const allFiles = readdirSync(claudeDir).filter(f => f.endsWith('.jsonl'));
+  const prefixMatches = allFiles.filter(f => f.startsWith(input));
+  if (prefixMatches.length === 1) return join(claudeDir, prefixMatches[0]!);
+  if (prefixMatches.length > 1) {
+    throw new Error(`Ambiguous session ID prefix '${input}' -- matches ${prefixMatches.length} sessions`);
+  }
+
+  const slugMatches: string[] = [];
+  for (const f of allFiles) {
+    const filePath = join(claudeDir, f);
+    try {
+      if (await fileContainsSlug(filePath, input)) slugMatches.push(filePath);
+    } catch {
+      // Skip unreadable files during slug search.
+    }
+  }
+  if (slugMatches.length === 1) return slugMatches[0]!;
+  if (slugMatches.length > 1) {
+    throw new Error(`Ambiguous slug '${input}' -- matches ${slugMatches.length} sessions`);
+  }
+
+  throw new Error(`No session found matching '${input}'`);
+}
+
+export async function resolveSessionFile(claudeDir: string, input: string): Promise<ResolvedFile> {
+  if (!input) throw new Error('Session ID is required');
+
+  const colonIdx = input.indexOf(':');
+  if (colonIdx !== -1) {
+    const sessionPart = input.slice(0, colonIdx);
+    const agentId = input.slice(colonIdx + 1);
+    validateSessionInput(sessionPart);
+    if (!/^[a-zA-Z0-9_-]+$/.test(agentId)) {
+      throw new Error('Invalid agent ID -- only alphanumeric characters, hyphens, and underscores allowed');
+    }
+
+    const parentFile = await resolveByIdOrSlug(claudeDir, sessionPart);
+    const parentUuid = basename(parentFile, '.jsonl');
+    const subagentFile = join(claudeDir, parentUuid, 'subagents', `agent-${agentId}.jsonl`);
+    if (!existsSync(subagentFile)) {
+      throw new Error(`No subagent '${agentId}' found for session '${parentUuid}'`);
+    }
+    return { filePath: subagentFile, sessionId: parentUuid, agentId };
+  }
+
+  const filePath = await resolveByIdOrSlug(claudeDir, input);
+  return { filePath, sessionId: basename(filePath, '.jsonl'), agentId: null };
+}
+
+export async function resolveSessionWithText(args: {
+  session: string;
+  project?: string;
+  'claude-project'?: string;
+  claudeProjectsRoot?: string;
+  selector?: SessionProjectSelector;
+}): Promise<ResolvedSessionWithText> {
+  const selector = args.selector ?? sessionProjectSelectorFromArgs(args);
+  const claudeDir = resolveClaudeProjectDirFromSelector(selector, args.claudeProjectsRoot);
+  const resolved = await resolveSessionFile(claudeDir, args.session);
+  const text = await Bun.file(resolved.filePath).text();
+  const allEntries = parseSessionText(text);
+  return {
+    ...resolved,
+    text,
+    allEntries,
+    entries: userAssistantEntries(allEntries),
+    lineCount: countNonEmptyLines(text),
+    metadata: extractSessionMetadata(text),
+  };
+}
+
+export function truncateContent(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen) + `...[truncated, ${text.length} chars]`;
+}
+
+export function maxCharsForTruncationKind(policy: TruncationPolicy, kind: TruncationKind): number | null {
+  switch (kind) {
+    case 'text':
+      return policy.textMaxChars ?? policy.defaultMaxChars ?? null;
+    case 'thinking':
+      return policy.thinkingMaxChars ?? policy.defaultMaxChars ?? null;
+    case 'tool_result':
+      return policy.toolResultMaxChars ?? policy.defaultMaxChars ?? null;
+    case 'raw_entry':
+      return policy.rawEntryMaxChars ?? policy.defaultMaxChars ?? null;
+  }
+}
+
+export function applyTruncationPolicy(text: string, policy: TruncationPolicy, kind: TruncationKind): string {
+  const maxChars = maxCharsForTruncationKind(policy, kind);
+  return maxChars == null ? text : truncateContent(text, maxChars);
+}
+
+const SUMMARY_SNIPPET_CHARS = 400;
+
+function summarySnippet(text: string): string {
+  return truncateContent(text, SUMMARY_SNIPPET_CHARS);
+}
+
+function timestampBounds(entries: SessionEntry[]): { startedAt: string | null; endedAt: string | null } {
+  let startedAt: string | null = null;
+  let endedAt: string | null = null;
+  for (const entry of entries) {
+    if (!entry.timestamp) continue;
+    if (startedAt === null) startedAt = entry.timestamp;
+    endedAt = entry.timestamp;
+  }
+  return { startedAt, endedAt };
+}
+
+function durationMs(startedAt: string | null, endedAt: string | null): number | null {
+  if (!startedAt || !endedAt) return null;
+  const start = new Date(startedAt).getTime();
+  const end = new Date(endedAt).getTime();
+  if (Number.isNaN(start) || Number.isNaN(end) || end < start) return null;
+  return end - start;
+}
+
+function summaryFileOperation(toolName: string): keyof SessionSummaryResult['files_touched'] | null {
+  switch (toolName) {
+    case 'Read': return 'read';
+    case 'Edit': return 'edit';
+    case 'Write': return 'write';
+    case 'Grep': return 'grep';
+    case 'Glob': return 'glob';
+    default: return null;
+  }
+}
+
+export function buildSessionSummary(args: {
+  sessionId: string;
+  agentId: string | null;
+  entries: SessionEntry[];
+  metadata: SessionMetadata;
+  lineCount: number | null;
+  subagents?: SubagentInfo[];
+}): SessionSummaryResult {
+  const normalized = normalizedBlocks(args.entries);
+  const { startedAt, endedAt } = timestampBounds(args.entries);
+  const toolCounts: Record<string, number> = {};
+  const filesTouched: SessionSummaryResult['files_touched'] = {
+    read: 0,
+    edit: 0,
+    write: 0,
+    grep: 0,
+    glob: 0,
+  };
+
+  for (const block of normalized) {
+    if (block.block.type !== 'tool_use' || !block.block.name) continue;
+    toolCounts[block.block.name] = (toolCounts[block.block.name] ?? 0) + 1;
+    const operation = summaryFileOperation(block.block.name);
+    if (operation) filesTouched[operation]++;
+  }
+
+  const firstUserText = normalized.find(block =>
+    block.role === 'user' &&
+    block.block.type === 'text' &&
+    typeof block.block.text === 'string' &&
+    block.block.text.length > 0
+  );
+  const assistantTextBlocks = normalized.filter(block =>
+    block.role === 'assistant' &&
+    block.block.type === 'text' &&
+    typeof block.block.text === 'string' &&
+    block.block.text.length > 0
+  );
+  const lastAssistantText = assistantTextBlocks[assistantTextBlocks.length - 1] ?? null;
+
+  return {
+    session_id: args.sessionId,
+    agent_id: args.agentId,
+    branch: args.metadata.branch,
+    model: args.metadata.model,
+    started_at: startedAt,
+    ended_at: endedAt,
+    duration_ms: durationMs(startedAt, endedAt),
+    turn_count: userAssistantEntries(args.entries).length,
+    lines: args.lineCount,
+    slug: args.metadata.slug,
+    first_user_prompt: firstUserText?.block.text
+      ? { turn: firstUserText.turn, snippet: summarySnippet(firstUserText.block.text) }
+      : null,
+    last_assistant_text: lastAssistantText?.block.text
+      ? { turn: lastAssistantText.turn, snippet: summarySnippet(lastAssistantText.block.text) }
+      : null,
+    tool_counts: toolCounts,
+    files_touched: filesTouched,
+    subagents: args.subagents ?? [],
+  };
+}


### PR DESCRIPTION
## Summary

- add agent-oriented `summary` and `projects` commands for faster session triage
- make project listing and search worktree-aware by default while preserving explicit main-checkout and all-project audit modes
- expand search with user/assistant text filters, regex matching, intent/evidence output, subagent inclusion, and counter aggregation buckets
- factor transcript, project-selection, and search behavior into shared `src/` modules with focused test coverage

## Review fixes included

- ensure new shared modules are tracked and covered by the TypeScript check
- make regex filters case-sensitive by default
- deduplicate related project selection and clarify session-targeting README wording
- add coverage configuration and coverage-focused tests for the refactored helpers

## Verification

- `bun test`
- `bun x tsc --noEmit`
- compiled CLI smoke test
- `bun test --coverage`
